### PR TITLE
Refactor Reminder creation loop

### DIFF
--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -23,21 +23,21 @@ class Reminder < ActiveRecord::Base
   # method looks up when the meeting should have been held for the given kid
   # in the week of time and creates a reminder according to these settings
   def self.create_for(kid, time)
-    r = Reminder.new
-    r.kid = kid
-    r.mentor = kid.mentor
-    r.secondary_mentor = kid.secondary_mentor
-    r.held_at = kid.calculate_meeting_time(time)
-    r.week = r.held_at.strftime('%U')
-    r.year = r.held_at.year
-    # the recipient of the reminder should be the active mentor
-    if kid.secondary_active? && kid.secondary_mentor
-      r.recipient = kid.secondary_mentor.email
-    else
-      r.recipient = kid.mentor.try(:email)
+    Reminder.new.tap do |r|
+      r.kid = kid
+      r.mentor = kid.mentor
+      r.secondary_mentor = kid.secondary_mentor
+      r.held_at = kid.calculate_meeting_time(time)
+      r.week = r.held_at.strftime('%U')
+      r.year = r.held_at.year
+      # the recipient of the reminder should be the active mentor
+      if kid.secondary_active? && kid.secondary_mentor
+        r.recipient = kid.secondary_mentor.email
+      else
+        r.recipient = kid.mentor.try(:email)
+      end
+      r.save!
     end
-    r.save!
-    r
   end
 
   # scans all kids and creates reminders for kids that meet the conditions

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -54,9 +54,9 @@ class Reminder < ActiveRecord::Base
     logger.flush
 
     reminders_created_count =
-      Kid.all.find_each.select do |kid|
+      Kid.all.find_each.count do |kid|
         self.conditionally_create_reminder_for_kid(time, kid)
-      end.count
+      end
 
     # send out admin notification when reminders were created
     if reminders_created_count > 0

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -23,7 +23,7 @@ class Reminder < ActiveRecord::Base
   # method looks up when the meeting should have been held for the given kid
   # in the week of time and creates a reminder according to these settings
   def self.create_for(kid, time)
-    Reminder.new.tap do |r|
+    Reminder.create! do |r|
       r.kid = kid
       r.mentor = kid.mentor
       r.secondary_mentor = kid.secondary_mentor
@@ -36,7 +36,6 @@ class Reminder < ActiveRecord::Base
       else
         r.recipient = kid.mentor.try(:email)
       end
-      r.save!
     end
   end
 


### PR DESCRIPTION
Based off of a CodeClimate issue https://codeclimate.com/github/panterch/future_kids/app/models/reminder.rb

- Extracts individual conditional kid reminder into separate method (returning true or false if reminder was created) -> Maybe this could be extracted into a Service class instead?
- Moves the rescue to cover the whole method
- Uses a case statement instead of multiple `if -> next` combinations
- Makes the log strings a bit more DRY