### PR TITLE
Delegate the Mentor's journal month_count to the DB

### DIFF
--- a/app/models/mentor.rb
+++ b/app/models/mentor.rb
@@ -42,9 +42,7 @@ class Mentor < User
   end
 
   def month_count
-    Journal.unscoped.where(mentor_id: id).map do |j|
-      "#{j.month} #{j.year}"
-    end.uniq.size
+    Journal.unscoped.where(mentor_id: id).select('DISTINCT (month, year)').count
   end
 
   def human_exit_kind


### PR DESCRIPTION
Instead of loading the records to Ruby, interpolating and counting - the calculation is done in the DB directly using [DISTINCT](http://www.postgresql.org/docs/9.5/static/sql-select.html#SQL-DISTINCT).

See https://github.com/rails/rails/issues/5554 for why `#select` is used (issue with counting distinct on multiple columns)

#### SQL Explains on two possible queries:

**1**

```ruby
Journal.unscoped.where(mentor_id: id).select('DISTINCT (month, year)').count
```
results in:

```
future_kids_development=# explain SELECT COUNT(DISTINCT (month, year)) FROM "journals" WHERE "journals"."mentor_id" = 1;
                                           QUERY PLAN
------------------------------------------------------------------------------------------------
 Aggregate  (cost=9.51..9.52 rows=1 width=8)
   ->  Bitmap Heap Scan on journals  (cost=4.16..9.50 rows=2 width=8)
         Recheck Cond: (mentor_id = 1)
         ->  Bitmap Index Scan on index_journals_on_mentor_id  (cost=0.00..4.16 rows=2 width=0)
               Index Cond: (mentor_id = 1)
```

**2**

Maybe a more readable approach is using the relationship directly:

```ruby
journals.select('DISTINCT (month, year)').count
```
```
future_kids_development=# explain SELECT COUNT(DISTINCT (month, year)) FROM "journals" INNER JOIN "kids" ON "kids"."id" = "journals"."kid_id" WHERE "journals"."mentor_id" = 1;                                                 QUERY PLAN
------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=20.78..20.79 rows=1 width=8)
   ->  Hash Join  (cost=9.53..20.78 rows=1 width=8)
         Hash Cond: (kids.id = journals.kid_id)
         ->  Seq Scan on kids  (cost=0.00..10.90 rows=90 width=4)
         ->  Hash  (cost=9.50..9.50 rows=2 width=12)
               ->  Bitmap Heap Scan on journals  (cost=4.16..9.50 rows=2 width=12)
                     Recheck Cond: (mentor_id = 1)
                     ->  Bitmap Index Scan on index_journals_on_mentor_id  (cost=0.00..4.16 rows=2 width=0)
                           Index Cond: (mentor_id = 1)
```

Both work but with the second it looks like the cost is higher since you get this unnecessary join when you don't remove the default scope of Journal.