### PR TITLE
Adapted email receivers on comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -10,6 +10,7 @@ class CommentsController < ApplicationController
   def create
     @comment = @journal.comments.build(comment_params)
     authorize! :create, @comment
+    @comment.created_by = current_user
     if @comment.save
       redirect_to kid_url(id: @journal.kid_id)
     else

--- a/app/mailers/notifications.rb
+++ b/app/mailers/notifications.rb
@@ -17,10 +17,11 @@ class Notifications < ActionMailer::Base
   end
 
   def comment_created(comment)
+    @site = Site.first_or_create!
     @comment = comment
     @journal = comment.journal
     @kid = @journal.kid
-    mail to: @comment.recipients
+    mail to: @comment.recipients, bcc: @site.comment_bcc
   end
 
   def test(to)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,11 +4,13 @@ class Comment < ApplicationRecord
   after_create :send_notification
 
   belongs_to :journal
+  belongs_to :created_by, class_name: 'User'
 
   default_scope { order('id') }
   validates_presence_of :body, :by, :journal_id
 
   def initialize_default_values(current_user)
+    self.created_by = current_user
     self.by ||= current_user.display_name
     if (previous = previous_comment)
       self.to_teacher = previous.to_teacher
@@ -42,6 +44,9 @@ class Comment < ApplicationRecord
     to << kid.teacher&.email if self.to_teacher?
     to << kid.secondary_teacher&.email if self.to_secondary_teacher?
     to << kid.third_teacher&.email if self.to_third_teacher?
+
+    # do not send emails out to the original creator
+    to.delete(self.created_by.try(:email))
     to.compact
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,7 +10,6 @@ class Comment < ApplicationRecord
   validates_presence_of :body, :by, :journal_id
 
   def initialize_default_values(current_user)
-    self.created_by = current_user
     self.by ||= current_user.display_name
     if (previous = previous_comment)
       self.to_teacher = previous.to_teacher

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -46,7 +46,18 @@ class Comment < ApplicationRecord
 
     # do not send emails out to the original creator
     to.delete(self.created_by.try(:email))
-    to.compact
+
+    to.compact!
+
+    # guard against the edge case where no receiver at all for the email
+    # is left at all
+    if to.empty?
+      fallback_email = Site.first_or_create.comment_bcc
+      fallback_email ||= I18n.t('notifications.default_email')
+      to << fallback_email
+    end
+
+    to
   end
 
   def human_body

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -4,6 +4,7 @@
   = form.input :term_collection_start
   = form.input :term_collection_end
   = form.input :feature_coach
+  = form.input :comment_bcc
   = form.input :logo
 
   .col-sm-offset-3.col-sm-9

--- a/config/locales/future_kids.de.yml
+++ b/config/locales/future_kids.de.yml
@@ -177,6 +177,7 @@ de:
         footer_email: Email Adresse in Fusszeile
         term_collection_start: Erstes Jahr Semesterauswahl
         term_collection_end: Letztes Jahr Semesterauswahl
+        comment_bcc: Email Adresse für alle Kommentare (bcc:)
       substitution:
         kid: "Kind"
         mentor: "Mentor/in"

--- a/db/migrate/20180531173049_add_comment_bcc_e_mail_to_site.rb
+++ b/db/migrate/20180531173049_add_comment_bcc_e_mail_to_site.rb
@@ -1,0 +1,5 @@
+class AddCommentBccEMailToSite < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sites, :comment_bcc, :string
+  end
+end

--- a/db/migrate/20180531175849_add_creator_to_comments.rb
+++ b/db/migrate/20180531175849_add_creator_to_comments.rb
@@ -1,0 +1,5 @@
+class AddCreatorToComments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :comments, :created_by_id, :integer
+  end
+end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe CommentsController do
   before(:each) do
     @mentor = create(:mentor)
-    @kid = create(:kid, mentor: @mentor)
+    @coach = create(:admin)
+    @kid = create(:kid, mentor: @mentor, admin: @coach)
     @journal =  create(:journal, kid: @kid, mentor: @mentor)
     ActionMailer::Base.deliveries.clear
   end

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -49,6 +49,18 @@ describe Notifications do
     end
   end
 
+  describe 'comment created with site wide bcc feature' do
+    before(:each) do
+      Site.first.update_attribute(:comment_bcc, 'bcc@example.com')
+      @comment = create(:comment)
+      @mail = Notifications.comment_created(@comment)
+    end
+
+    it 'renders the body' do
+      expect(@mail.bcc.first).to eq('bcc@example.com')
+    end
+  end
+
   describe 'journal' do
     before(:each) do
       @admin    = create(:admin, email: 'admin@example.com')

--- a/spec/mailers/notifications_spec.rb
+++ b/spec/mailers/notifications_spec.rb
@@ -51,7 +51,7 @@ describe Notifications do
 
   describe 'comment created with site wide bcc feature' do
     before(:each) do
-      Site.first.update_attribute(:comment_bcc, 'bcc@example.com')
+      Site.create!(comment_bcc: 'bcc@example.com')
       @comment = create(:comment)
       @mail = Notifications.comment_created(@comment)
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -46,7 +46,7 @@ describe Comment do
     end
     it 'is not the mentor when he is the sender' do
       @comment.created_by = @kid.mentor
-      expect(@comment.recipients).to eq([])
+      expect(@comment.recipients).not_to include(@kid.mentor.email)
     end
     it 'add the coach when present' do
       @coach = create(:admin)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -32,6 +32,12 @@ describe Comment do
       expect(@comment.to_teacher).to eq(true)
       expect(@comment.to_secondary_teacher).to eq(false)
     end
+
+    it 'sets created_by' do
+      @mentor = create(:mentor)
+      @comment.initialize_default_values(@mentor)
+      expect(@comment.created_by).to eq(@mentor)
+    end
   end
 
   context 'recipients' do
@@ -42,6 +48,10 @@ describe Comment do
     end
     it 'is the mentor' do
       expect(@comment.recipients).to eq([@kid.mentor.email])
+    end
+    it 'is not the mentor when he is the sender' do
+      @comment.created_by = @kid.mentor
+      expect(@comment.recipients).to eq([])
     end
     it 'add the coach when present' do
       @coach = create(:admin)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -33,11 +33,6 @@ describe Comment do
       expect(@comment.to_secondary_teacher).to eq(false)
     end
 
-    it 'sets created_by' do
-      @mentor = create(:mentor)
-      @comment.initialize_default_values(@mentor)
-      expect(@comment.created_by).to eq(@mentor)
-    end
   end
 
   context 'recipients' do


### PR DESCRIPTION
- Under sitewide configuration a bcc: email may be specified which receives all comment emails
- The editor of a comment is excluded as receiver