### PR TITLE
Fix SQL injection problems

### DIFF
--- a/app/controllers/kid_mentor_relations_controller.rb
+++ b/app/controllers/kid_mentor_relations_controller.rb
@@ -7,7 +7,9 @@ class KidMentorRelationsController < ApplicationController
     #
     # all fields to filter here have to be present in the sql view
     @kid_mentor_relation = KidMentorRelation.new(filter_params)
-    @kid_mentor_relations = @kid_mentor_relations.where(filter_params.to_h.delete_if { |_key, val| val.blank? })
+    @kid_mentor_relations = @kid_mentor_relations.where(filter_params.to_h.delete_if do |key, val|
+      !KidMentorRelation.column_names.include?(key.to_s) || val.blank?
+    end)
     if params['order_by'] && valid_order_by?(Kid, params['order_by'])
       @kid_mentor_relations = @kid_mentor_relations.reorder(params['order_by'])
     else

--- a/app/controllers/kids_controller.rb
+++ b/app/controllers/kids_controller.rb
@@ -25,7 +25,7 @@ class KidsController < ApplicationController
       # build a where condition out of all parameters supplied for kid
       params[:kid] ||= {}
       params[:kid][:inactive] = '0' if params[:kid][:inactive].nil?
-      @kids = @kids.where(kid_params.to_h.delete_if { |_key, val| val.blank? })
+      @kids = @kids.where(kid_params.to_h.delete_if { |key, val| !Kid.column_names.include?(key.to_s) || val.blank? })
       # reorder the kids according to the supplied parameter
 
       if params['order_by'] && valid_order_by?(Kid, params['order_by'])


### PR DESCRIPTION
Ref. #202.

The current implementation of `valid_order_by?` is enough to prevent SQL injection in the `ORDER BY` clause, so no problems there. The SQL injection vulnerability in the `where` calls comes from the hash keys, which Rails assumes are sanitized (as opposed to parameterizing or escaping them, as it does for the values). This fixes that by dropping hash keys if they're not one of the relevant model's column names, much like `valid_order_by?` does.