### PR TITLE
Refactor: rename user state

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ protected
     return true if 'sessions' == controller_name
     return true if controller_name == 'self_registrations'
     return true unless user_signed_in?
-    return true if current_user.state == 'confirmed' && !current_user.inactive?
+    return true if current_user.state == 'accepted' && !current_user.inactive?
 
     sign_out current_user
     redirect_to root_url, alert: 'Benutzer/in inaktiv'

--- a/app/controllers/mentors_controller.rb
+++ b/app/controllers/mentors_controller.rb
@@ -71,8 +71,8 @@ class MentorsController < ApplicationController
       respond_with @mentor, notice: I18n.t('mentors.form.resend_password.sent_successfully')
       return
     end
-    # switched to confirmed state
-    if mentor_params[:state] == 'confirmed' && @mentor.state != mentor_params[:state]
+    # switched to accepted state
+    if mentor_params[:state] == 'accepted' && @mentor.state != mentor_params[:state]
       SelfRegistrationsMailer.reset_and_send_password(@mentor).deliver_now
     end
 

--- a/app/controllers/self_registrations_controller.rb
+++ b/app/controllers/self_registrations_controller.rb
@@ -27,7 +27,7 @@ class SelfRegistrationsController < ApplicationController
       :type, :email, :name, :prename, :sex, :address, :photo, :dob, :phone, :school, :field_of_study
     )
     new_password = Devise.friendly_token.first(10)
-    p.merge password: new_password, password_confirmation: new_password, state: :unproven
+    p.merge password: new_password, password_confirmation: new_password, state: :selfservice
   end
 
   def redirect_if_signed_in

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -35,8 +35,8 @@ class TeachersController < ApplicationController
       respond_with @teacher, notice: I18n.t('teachers.form.resend_password.sent_successfully')
       return
     end
-    # switched to confirmed state
-    if teacher_params[:state] == 'confirmed' && @teacher.state != teacher_params[:state]
+    # switched to accepted state
+    if teacher_params[:state] == 'accepted' && @teacher.state != teacher_params[:state]
       SelfRegistrationsMailer.reset_and_send_password(@teacher).deliver_now
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,11 +16,11 @@ class User < ApplicationRecord
 
   has_many :relation_logs, -> { order('created_at DESC') }, dependent: :nullify
 
-  enum state: { unproven: 'unproven',
-                lebendeleife: 'lebendeleife',
-                zur_wahrnehmung: 'zur_wahrnehmung',
-                confirmed: 'confirmed',
-                cancelled: 'cancelled' }
+  enum state: { selfservice: 'selfservice',
+                queued: 'queued',
+                invited: 'invited',
+                accepted: 'accepted',
+                declined: 'declined' }
 
   def display_name
     [name, prename].reject(&:blank?).join(' ')

--- a/config/locales/future_kids.de.yml
+++ b/config/locales/future_kids.de.yml
@@ -154,11 +154,11 @@ de:
         note: Bemerkungen
         state: Zustand
         states:
-          unproven: Neu erfasst
-          lebendeleife: Warteschleife
-          zur_wahrnehmung: Zur Schulung eingeladen
-          confirmed: Zusage
-          cancelled: Absage
+          selfservice: Neu erfasst
+          queued: Warteschleife
+          invited: Zur Schulung eingeladen
+          accepted: Zusage
+          declined: Absage
       mentor:
         available: "Mögliche Termine"
         absence: "Bekannte Absenzen / Verfügbarkeit"

--- a/db/migrate/20210517150849_change_user_state_from_confirmed_to_accepted.rb
+++ b/db/migrate/20210517150849_change_user_state_from_confirmed_to_accepted.rb
@@ -1,0 +1,6 @@
+class ChangeUserStateFromConfirmedToAccepted < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default(:users, :state, 'accepted')
+    execute("UPDATE users SET state = 'accepted';")
+  end
+end

--- a/spec/controllers/mentors_controller_spec.rb
+++ b/spec/controllers/mentors_controller_spec.rb
@@ -44,10 +44,10 @@ describe MentorsController do
     context 'update' do 
       it 'cannot update its state' do
         expect do
-          put :update, params: { id: @mentor.id, mentor: { state: :cancelled } }
+          put :update, params: { id: @mentor.id, mentor: { state: :declined } }
         end.to raise_error(SecurityError)
 
-        expect(@mentor.reload.state).to eq 'confirmed'
+        expect(@mentor.reload.state).to eq 'accepted'
       end
     end
   end
@@ -87,13 +87,13 @@ describe MentorsController do
 
     context 'update' do
       it 'can update state' do
-        patch :update, params: { id: @mentor.id, mentor: { state: :cancelled } }
-        expect(@mentor.reload.state).to eq 'cancelled'
+        patch :update, params: { id: @mentor.id, mentor: { state: :declined } }
+        expect(@mentor.reload.state).to eq 'declined'
       end
 
       it 'sends email if state updated to accepted' do
-        @mentor.update(state: :unproven)
-        patch :update, params: { id: @mentor.id, mentor: { state: :confirmed } }
+        @mentor.update(state: :selfservice)
+        patch :update, params: { id: @mentor.id, mentor: { state: :accepted } }
         last_email = ActionMailer::Base.deliveries.last
         expect(last_email.subject).to eq I18n.translate('self_registrations_mailer.reset_and_send_password.subject')
       end
@@ -103,7 +103,7 @@ describe MentorsController do
         expect(ActionMailer::Base.deliveries.count).to eq 0
       end
 
-      it 'resends email with password if confirmed with resend password button' do
+      it 'resends email with password with resend password button if user is accepted' do
         patch :update, params: { id: @mentor.id, commit: I18n.translate('teachers.form.resend_password.btn_text') }
         last_email = ActionMailer::Base.deliveries.last
         expect(last_email.subject).to eq I18n.translate('self_registrations_mailer.reset_and_send_password.subject')

--- a/spec/controllers/self_registrations_controller_spec.rb
+++ b/spec/controllers/self_registrations_controller_spec.rb
@@ -25,8 +25,8 @@ describe SelfRegistrationsController do
         expect(response).to redirect_to action: :success
       end
 
-      it 'created teacher has unproven status' do
-        expect(Teacher.first.state).to eq 'unproven'
+      it 'created teacher has selfservice status' do
+        expect(Teacher.first.state).to eq 'selfservice'
       end
 
       it 'sends email to all admins' do
@@ -35,9 +35,9 @@ describe SelfRegistrationsController do
       end
 
       it "can't force state" do
-        post :create, params: { teacher: attributes_for(:teacher).merge(type: 'Teacher', state: :confirmed) }
+        post :create, params: { teacher: attributes_for(:teacher).merge(type: 'Teacher', state: :accepted) }
         expect(response).to redirect_to action: :success
-        expect(Teacher.last.state).to eq 'unproven'
+        expect(Teacher.last.state).to eq 'selfservice'
       end
     end
 
@@ -55,8 +55,8 @@ describe SelfRegistrationsController do
         expect(response).to redirect_to action: :success
       end
 
-      it 'created teacher has unproven status' do
-        expect(Mentor.first.state).to eq 'unproven'
+      it 'created teacher has selfservice status' do
+        expect(Mentor.first.state).to eq 'selfservice'
       end
 
       it 'sends email to all admins' do
@@ -65,9 +65,9 @@ describe SelfRegistrationsController do
       end
 
       it "can't force state" do
-        post :create, params: { mentor: attributes_for(:mentor).merge(type: 'Mentor', state: :confirmed) }
+        post :create, params: { mentor: attributes_for(:mentor).merge(type: 'Mentor', state: :accepted) }
         expect(response).to redirect_to action: :success
-        expect(Mentor.last.state).to eq 'unproven'
+        expect(Mentor.last.state).to eq 'selfservice'
       end
     end
   end

--- a/spec/controllers/teachers_controller_spec.rb
+++ b/spec/controllers/teachers_controller_spec.rb
@@ -44,13 +44,13 @@ describe TeachersController do
     context 'update' do
       it 'can update state' do
         @teacher = create(:teacher)
-        patch :update, params: { id: @teacher.id, teacher: { state: :cancelled } }
-        expect(@teacher.reload.state).to eq 'cancelled'
+        patch :update, params: { id: @teacher.id, teacher: { state: :declined } }
+        expect(@teacher.reload.state).to eq 'declined'
       end
 
       it 'sends email if state updated to accepted' do
-        @teacher = create(:teacher, state: :unproven)
-        patch :update, params: { id: @teacher.id, teacher: { state: :confirmed } }
+        @teacher = create(:teacher, state: :selfservice)
+        patch :update, params: { id: @teacher.id, teacher: { state: :accepted } }
         last_email = ActionMailer::Base.deliveries.last
         expect(last_email.subject).to eq I18n.translate('self_registrations_mailer.reset_and_send_password.subject')
       end
@@ -61,7 +61,7 @@ describe TeachersController do
         expect(ActionMailer::Base.deliveries.count).to eq 0
       end
 
-      it 'resends email with password if confirmed with resend password button' do
+      it 'resends email with password with resend password button if user is accepted' do
         @teacher = create(:teacher)
         patch :update, params: { id: @teacher.id, commit: I18n.translate('teachers.form.resend_password.btn_text') }
         last_email = ActionMailer::Base.deliveries.last
@@ -120,7 +120,7 @@ describe TeachersController do
         put :create, params: { teacher: teacher_params }
         expect(response).to be_redirect
         expect(Teacher.count).to eq(1)
-        expect(Teacher.first.reload.state).to eq 'confirmed'
+        expect(Teacher.first.reload.state).to eq 'accepted'
       end
       it 'fails when creating teacher for foreign schools' do
         teacher_params[:school_id] = create(:school).id
@@ -155,10 +155,10 @@ describe TeachersController do
 
       it 'cannot update its state' do
         expect do
-          put :update, params: { id: @teacher.id, teacher: { state: :cancelled }  }
+          put :update, params: { id: @teacher.id, teacher: { state: :declined }  }
         end.to raise_error(SecurityError)
 
-        expect(@teacher.reload.state).to eq 'confirmed'
+        expect(@teacher.reload.state).to eq 'accepted'
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     sequence(:email) { |n| "email_#{n}@example.com" }
     password { 'welcome' }
     password_confirmation { 'welcome' }
-    state { 'confirmed' }
+    state { 'accepted' }
   end
 
   factory :admin, class: 'Admin', parent: :user do

--- a/spec/requests/login_stories_spec.rb
+++ b/spec/requests/login_stories_spec.rb
@@ -36,8 +36,8 @@ feature 'SESSION::LOGIN', '
     expect(page).to have_content('Anmelden')
   end
 
-  scenario 'should login only confirmed users' do
-    invalid_states = [:unproven, :lebendeleife, :zur_wahrnehmung, :cancelled]
+  scenario 'should login only accepted users' do
+    invalid_states = [:selfservice, :queued, :invited, :declined]
 
     invalid_states.each do |invalid_state|
       @mentor.update_attribute(:state, invalid_state)
@@ -48,7 +48,7 @@ feature 'SESSION::LOGIN', '
       expect(page).to have_content('Anmelden')
     end
 
-    @mentor.update_attribute(:state, :confirmed)
+    @mentor.update_attribute(:state, :accepted)
     visit new_user_session_path
     fill_in 'user_email',    with: @mentor.email
     fill_in 'user_password', with: @pw


### PR DESCRIPTION
Renaming user state.

When we merge other PRs, I would like to rebase this one, so we have correct states accross app.