### PR TITLE
fix: self registration user type whitelist on create

### DIFF
--- a/spec/controllers/self_registrations_controller_spec.rb
+++ b/spec/controllers/self_registrations_controller_spec.rb
@@ -81,6 +81,14 @@ describe SelfRegistrationsController do
           expect(response).to have_http_status :success
         end
       end
+
+      context 'other' do
+        it "returns unauthorized" do
+          params = { mentor: attributes_for(:mentor).merge(type: 'Admin'), terms_of_use: { accepted: "yes" } }
+          post :create, params: params
+          expect(response).to have_http_status :unauthorized
+        end
+      end
     end
 
     context 'success' do


### PR DESCRIPTION
@mojpanter have noticed that I've introduced security vulnerability with the self registrations.
User could potentially force register self as unconfirmed Admin, this PR fixes that.