### PR TITLE
Track document download counts

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -16,6 +16,11 @@ class DocumentsController < ApplicationController
     end
   end
 
+  def show
+    @document.increment!(:download_count)
+    redirect_to rails_blob_path(@document.attachment.blob, only_path: true), allow_other_host: false
+  end
+
   def update
     @document.update(document_params)
     if @document.valid?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,8 +2,6 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    alias_action :download, to: :read
-
     if user.is_a?(Admin)
       can :manage, :all
       cannot :create, MentorMatching

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,6 +2,8 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
+    alias_action :download, to: :read
+
     if user.is_a?(Admin)
       can :manage, :all
       cannot :create, MentorMatching

--- a/app/models/document_treeview.rb
+++ b/app/models/document_treeview.rb
@@ -48,7 +48,7 @@ class DocumentTreeview
       end
       nodes << {
         text: d.title,
-        href: Rails.application.routes.url_helpers.rails_blob_path(d.attachment.blob, only_path: true),
+        href: Rails.application.routes.url_helpers.document_path(d),
         documentId: d.id,
         icon: 'glyphicon glyphicon-book'
       }

--- a/app/views/documents/_form.html.haml
+++ b/app/views/documents/_form.html.haml
@@ -11,6 +11,11 @@
   = form.input :title
   = form.input :attachment
   = form.input :admin_only, as: :boolean, label: Document.human_attribute_name(:admin_only)
+  - if @document.persisted?
+    .form-group
+      %label.col-sm-3.control-label= Document.human_attribute_name(:download_count)
+      .col-sm-9
+        %p.form-control-static= @document.download_count
 
   .col-sm-offset-3.col-sm-9
     = form.button :submit

--- a/config/locales/future_kids.de.yml
+++ b/config/locales/future_kids.de.yml
@@ -231,6 +231,7 @@ de:
         description: Beschreibung
         attachment: Datei
         admin_only: "Nur für Admins und Coaches einsehbar"
+        download_count: "Anzahl Downloads"
       comment:
         by: 'Verfasser*in'
         body: Kommentar

--- a/db/migrate/20260408182213_add_download_count_to_documents.rb
+++ b/db/migrate/20260408182213_add_download_count_to_documents.rb
@@ -1,0 +1,5 @@
+class AddDownloadCountToDocuments < ActiveRecord::Migration[8.1]
+  def change
+    add_column :documents, :download_count, :integer, default: 0, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,8 +1,3 @@
-\restrict oFaQT2A6nnnmAakh9NTx82MalY0sBm9S6Zeqbl4SEmyTvPcI47O5LdGnlIFLgwx
-
--- Dumped from database version 16.10 (Homebrew)
--- Dumped by pg_dump version 16.10 (Homebrew)
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -201,7 +196,8 @@ CREATE TABLE public.documents (
     category5 character varying,
     category6 character varying,
     admin_only boolean DEFAULT false NOT NULL,
-    category7 character varying
+    category7 character varying,
+    download_count integer DEFAULT 0 NOT NULL
 );
 
 
@@ -1496,11 +1492,10 @@ ALTER TABLE ONLY public.mentor_matchings
 -- PostgreSQL database dump complete
 --
 
-\unrestrict oFaQT2A6nnnmAakh9NTx82MalY0sBm9S6Zeqbl4SEmyTvPcI47O5LdGnlIFLgwx
-
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260408182213'),
 ('20250913213902'),
 ('20250209132950'),
 ('20250105000000'),

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -11,6 +11,21 @@ describe DocumentsController do
                        admin_only: true).attachment.attach(file).record.save!
     end
 
+    it 'increments download_count and redirects to blob on show' do
+      document = Document.find_by(title: 'a1')
+      expect do
+        get :show, params: { id: document.id }
+      end.to change { document.reload.download_count }.by(1)
+      expect(response).to redirect_to(rails_blob_path(document.attachment.blob, only_path: true))
+    end
+
+    it 'cannot show admin-only documents' do
+      document = Document.find_by(title: 'ax1')
+      expect do
+        get :show, params: { id: document.id }
+      end.to raise_error(CanCan::AccessDenied)
+    end
+
     it 'can browse non-admin documents' do
       get :index
       expect(response).to have_http_status(:ok)

--- a/spec/controllers/documents_controller_spec.rb
+++ b/spec/controllers/documents_controller_spec.rb
@@ -48,6 +48,14 @@ describe DocumentsController do
                        admin_only: true).attachment.attach(file).record.save!
     end
 
+    it 'increments download_count and redirects to blob for admin-only documents' do
+      document = Document.find_by(title: 'ax1')
+      expect do
+        get :show, params: { id: document.id }
+      end.to change { document.reload.download_count }.by(1)
+      expect(response).to redirect_to(rails_blob_path(document.attachment.blob, only_path: true))
+    end
+
     it 'can browse all documents including admin-only ones' do
       get :index
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
## Summary

- Adds `download_count` column to documents via migration
- New `show` action increments the counter and redirects to the blob, so every download is tracked
- Treeview links now route through the controller (instead of directly to the blob) so counts are captured consistently
- Download count displayed as read-only field in the admin document form
- Authorization: `alias_action :download, to: :read` ensures existing permissions apply to the new action

## Test plan

- [ ] Existing tests pass (`bundle exec rspec spec/controllers/documents_controller_spec.rb`)
- [ ] Non-admin user can download a non-admin document; count increments
- [ ] Non-admin user cannot access an admin-only document (CanCan::AccessDenied)
- [ ] Admin sees download count in the document edit form

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documents now track download counts, which are incremented each time a document is accessed.
  * Download count is displayed as read-only information in the document details.
  * Access to documents is now routed through an authorization layer, ensuring proper permission checks before downloads are allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->