### PR TITLE
Replace jquery_ujs with rails-ujs

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,7 +5,7 @@
 // the compiled file.
 //
 //= require jquery
-//= require jquery_ujs
+//= require rails-ujs
 //= require bootstrap
 //= require jquery.calendrical
 //= require jquery.disable


### PR DESCRIPTION
jquery_ujs is jQuery-dependent; rails-ujs is the vanilla JS drop-in replacement shipped with Rails 7, covering method overrides, confirm dialogs, remote forms, and disable-with — with no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the JavaScript library responsible for interactive features to align with current Rails standards and improve application maintenance. This ensures better long-term compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->