### PR TITLE
Use meaningful filenames for xlsx downloads

### DIFF
--- a/app/controllers/kid_mentor_relations_controller.rb
+++ b/app/controllers/kid_mentor_relations_controller.rb
@@ -17,7 +17,9 @@ class KidMentorRelationsController < ApplicationController
                               @kid_mentor_relations.reorder('kid_name')
                             end
 
-    return render xlsx: 'index' if 'xlsx' == params[:format]
+    if params[:format] == 'xlsx'
+      return render xlsx: 'index', filename: "kid-mentor-relations-#{Time.current.strftime('%Y-%m-%d-%H-%M')}.xlsx"
+    end
 
     respond_with @kid_mentor_relations
   end

--- a/app/controllers/kids_controller.rb
+++ b/app/controllers/kids_controller.rb
@@ -31,7 +31,9 @@ class KidsController < ApplicationController
       @kid = Kid.new(kid_params)
     end
 
-    return render xlsx: 'index' if current_user.is_a?(Admin) && 'xlsx' == params[:format]
+    if current_user.is_a?(Admin) && params[:format] == 'xlsx'
+      return render xlsx: 'index', filename: "kids-#{Time.current.strftime('%Y-%m-%d-%H-%M')}.xlsx"
+    end
 
     respond_with @kids
   end

--- a/app/controllers/mentors_controller.rb
+++ b/app/controllers/mentors_controller.rb
@@ -39,7 +39,7 @@ class MentorsController < ApplicationController
     @mentor = Mentor.new(mentor_params)
 
     if current_user.is_a?(Admin) && 'xlsx' == params[:format]
-      render xlsx: 'index'
+      render xlsx: 'index', filename: "mentors-#{Time.current.strftime('%Y-%m-%d-%H-%M')}.xlsx"
     # when only one record is present, show it immediately. this is not for
     # admins, since they could have no chance to alter their filter settings in
     # some cases

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -10,7 +10,7 @@ class SitesController < ApplicationController
       @journals = Journal.all
       @reviews = Review.all
       @assessments = FirstYearAssessment.all
-      render xlsx: 'show'
+      render xlsx: 'show', filename: "futurekids-#{Time.current.strftime('%Y-%m-%d-%H-%M')}.xlsx"
     # normal call redirects to the site wide features
     else
       redirect_to edit_site_url

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -3,13 +3,13 @@ class SitesController < ApplicationController
 
   def show
     # in xlsx format show is a full dump of the site
-    if 'xlsx' == params[:format]
-      @kids = Kid.all
-      @mentors = Mentor.all
-      @kid_mentor_relations = KidMentorRelation.all
-      @journals = Journal.all
-      @reviews = Review.all
-      @assessments = FirstYearAssessment.all
+    if params[:format] == 'xlsx'
+      @kids = Kid.includes(:school, :teacher, :mentor, :secondary_mentor, :admin)
+      @mentors = Mentor.includes(:school, :schools, :kids, :secondary_kids)
+      @kid_mentor_relations = KidMentorRelation.includes(:kid, :mentor, :school)
+      @journals = Journal.includes(:kid, :mentor)
+      @reviews = Review.includes(:kid)
+      @assessments = FirstYearAssessment.includes(:kid, :mentor, :teacher)
       render xlsx: 'show', filename: "futurekids-#{Time.current.strftime('%Y-%m-%d-%H-%M')}.xlsx"
     # normal call redirects to the site wide features
     else

--- a/spec/controllers/kid_mentor_relations_controller_spec.rb
+++ b/spec/controllers/kid_mentor_relations_controller_spec.rb
@@ -27,6 +27,7 @@ describe KidMentorRelationsController do
         create(:kid, exit_kind: 'exit', mentor: @mentor)
         get :index, format: 'xlsx'
         expect(response).to be_successful
+        expect(response.headers['Content-Disposition']).to match(/filename="kid-mentor-relations-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}\.xlsx"/)
       end
     end
   end # end of as an admin

--- a/spec/controllers/kids_controller_spec.rb
+++ b/spec/controllers/kids_controller_spec.rb
@@ -66,6 +66,7 @@ describe KidsController do
       it 'renders xlsx' do
         get :index, format: 'xlsx'
         expect(response).to be_successful
+        expect(response.headers['Content-Disposition']).to match(/filename="kids-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}\.xlsx"/)
       end
     end
 

--- a/spec/controllers/mentors_controller_spec.rb
+++ b/spec/controllers/mentors_controller_spec.rb
@@ -60,6 +60,7 @@ describe MentorsController do
       it 'renders xlsx' do
         get :index, format: 'xlsx'
         expect(response).to be_successful
+        expect(response.headers['Content-Disposition']).to match(/filename="mentors-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}\.xlsx"/)
       end
     end
   end

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -11,6 +11,7 @@ describe SitesController do
     it 'renders xlsx' do
       get :show, format: 'xlsx'
       expect(response).to be_successful
+      expect(response.headers['Content-Disposition']).to match(/filename="futurekids-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}\.xlsx"/)
     end
   end
 end


### PR DESCRIPTION
Downloads were all named index.xls (defaulting to the action name). Each export now gets a timestamped name like kids-2026-06-06-14-30.xlsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excel exports from all data management tables now include timestamps in filenames, enabling easier tracking of export dates and preventing file overwriting when downloading multiple reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->