### PR TITLE
Add filtering, sorting and richer table to schools index

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -4,6 +4,15 @@ class SchoolsController < ApplicationController
   load_and_authorize_resource
   include CrudActions
 
+  def index
+    filter = school_filter_params
+    @schools = apply_school_filter(@schools, filter)
+    @active_kids_counts = Kid.active.reorder(nil).where(school_id: @schools).group(:school_id).count
+    @schools = @schools.includes(:teachers, { principal_school_relations: :principal })
+    @school = School.new(filter)
+    respond_with @schools
+  end
+
   def create
     @school = School.new(school_params)
     if @school.save
@@ -22,6 +31,18 @@ class SchoolsController < ApplicationController
   end
 
   private
+
+  def apply_school_filter(schools, filter)
+    schools.where(
+      filter.to_h.delete_if { |key, val| School.column_names.exclude?(key.to_s) || val.blank? }
+    )
+  end
+
+  def school_filter_params
+    return {} if params[:school].blank?
+
+    params.expect(school: %i[school_kind district])
+  end
 
   def school_params
     params.expect(

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -169,6 +169,10 @@ module ApplicationHelper
     School.school_kinds.keys.map { |s| [School.humanize_enum('school_kind', s), s] }
   end
 
+  def school_district_collection
+    School.unscoped.distinct.order(:district).pluck(:district).compact_blank.map { |d| [d, d] }
+  end
+
   # can be used in view to display private data only to their owners (and
   # admins)
   def viewing_own_data?(resource)

--- a/app/views/schools/index.html.haml
+++ b/app/views/schools/index.html.haml
@@ -1,5 +1,5 @@
 - content_for :sidebar do
-  = form_for :school, url: { action: 'index' }, html: { method: :get, class: 'filter' } do |f|
+  = form_for @school, url: { action: 'index' }, html: { method: :get, class: 'filter' } do |f|
     .form-group
       %label= School.human_attribute_name(:school_kind)
       = f.select :school_kind, school_kind_collection, { include_blank: true }, class: 'form-control'

--- a/app/views/schools/index.html.haml
+++ b/app/views/schools/index.html.haml
@@ -1,10 +1,30 @@
-= boot_page_title
+- content_for :sidebar do
+  = form_for :school, url: { action: 'index' }, html: { method: :get, class: 'filter' } do |f|
+    .form-group
+      %label= School.human_attribute_name(:school_kind)
+      = f.select :school_kind, school_kind_collection, { include_blank: true }, class: 'form-control'
+    .form-group
+      %label= School.human_attribute_name(:district)
+      = f.select :district, school_district_collection, { include_blank: true }, class: 'form-control'
+    .form-group
+      = f.submit 'Suchen', class: 'btn btn-xs btn-success'
+      = link_to 'Filter aufheben', schools_path, class: 'btn btn-xs'
+
+= boot_page_title do
+  = @schools.count
+  Schulen
 
 %table.table.table-striped.table-condensed.table-hover
   %thead
     %tr
-      %th Name
+      %th= School.human_attribute_name(:name)
+      %th{style: 'white-space: nowrap'}= School.human_attribute_name(:school_kind)
+      %th Schüler*innen / Lehrpersonen
+      %th SL/QUIMS
   %tbody
     - @schools.each do |school|
       %tr
         %td= link_to school.name, school_path(school)
+        %td{style: 'white-space: nowrap'}= school.human_school_kind
+        %td= "#{@active_kids_counts[school.id].to_i} / #{school.teachers.count { |t| !t.inactive }}"
+        %td= school.principals.select { |p| !p.inactive }.map(&:display_name).join(', ')


### PR DESCRIPTION
- Filter by school_kind and district (Schulgemeinde) via sidebar
- Table now shows school_kind, active kids/teachers count, and principals
- Eager-load teachers and principals to avoid N+1; precompute kids counts with a single grouped query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering capability to the schools listing page. Users can now filter schools by kind and district.
  * Enhanced schools listing to display additional information including school kind, active student/teacher counts, and principals.
  * Added "Clear filters" option to reset applied filters.
  * Page title now shows the total school count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->