### PR TITLE
Redact real names from AI journal summaries before sending to third-party provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'sprockets-rails'
 
 gem 'actionview-encoded_mail_to'
 gem 'active_storage_validations'
+gem 'jaro_winkler'
 gem 'bootstrap-sass'
 gem 'cancancan'
 gem 'connection_pool'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jaro_winkler (1.7.0)
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -571,6 +572,7 @@ DEPENDENCIES
   haml-rails
   i18n_rails_helpers
   image_processing
+  jaro_winkler
   jbuilder
   jquery-rails
   letter_opener

--- a/app/controllers/kids_controller.rb
+++ b/app/controllers/kids_controller.rb
@@ -61,6 +61,8 @@ class KidsController < ApplicationController
     if params[:format] == 'md'
       raise CanCan::AccessDenied unless current_user.is_a?(Admin)
 
+      return render formats: [:md], locals: { redactor: NameRedactor.new(@kid) } if params[:redacted].present?
+
       return render formats: [:md]
     end
 

--- a/app/services/journal_summarizer.rb
+++ b/app/services/journal_summarizer.rb
@@ -56,6 +56,8 @@ class JournalSummarizer
     raise Error, 'Die Antwort der KI enthielt keine Zusammenfassung.' if content.blank?
 
     content.strip
+  rescue JSON::ParserError
+    raise Error, 'Die Antwort der KI konnte nicht gelesen werden.'
   end
 
   def request(prompt)
@@ -79,7 +81,7 @@ class JournalSummarizer
     raise Error, "Die Anfrage an die KI ist fehlgeschlagen (#{response.code})." unless response.is_a?(Net::HTTPSuccess)
 
     response
-  rescue Timeout::Error, SocketError, OpenSSL::SSL::SSLError => e
+  rescue Timeout::Error, SocketError, OpenSSL::SSL::SSLError, SystemCallError, EOFError => e
     raise Error, "Verbindung zur KI ist fehlgeschlagen: #{e.message}"
   end
 end

--- a/app/services/journal_summarizer.rb
+++ b/app/services/journal_summarizer.rb
@@ -9,7 +9,10 @@
 # The prompt is the kid's markdown profile (kids/show.md.erb - the same
 # template the admin-only "/kids/:id.md" view renders), which includes the
 # kid's name, support areas, mentor/teacher assignment history, and the full
-# chronological record (journals, Gespräche, assessments).
+# chronological record (journals, Gespräche, assessments). Real names are
+# redacted from the outgoing prompt via NameRedactor before it leaves the
+# app, and the AI's response is rehydrated back to real names afterwards -
+# see kids/:id.md?redacted=true for a preview of what actually gets sent.
 class JournalSummarizer
   class Error < StandardError; end
 
@@ -36,13 +39,15 @@ class JournalSummarizer
   def call
     raise Error, 'Es sind keine Lernjournal-Einträge vorhanden.' if @kid.journals.empty?
 
-    fetch_summary(build_prompt)
+    redactor = NameRedactor.new(@kid)
+    redactor.rehydrate(fetch_summary(build_prompt(redactor)))
   end
 
   private
 
-  def build_prompt
-    markdown = ApplicationController.renderer.render(template: 'kids/show', formats: [:md], assigns: { kid: @kid })
+  def build_prompt(redactor)
+    markdown = ApplicationController.renderer.render(template: 'kids/show', formats: [:md], assigns: { kid: @kid },
+                                                       locals: { redactor: redactor })
     "#{@site.ai_summary_prompt.presence || DEFAULT_PROMPT}\n\n#{markdown}"
   end
 

--- a/app/services/name_redactor.rb
+++ b/app/services/name_redactor.rb
@@ -94,7 +94,7 @@ class NameRedactor
   def rehydrate(text)
     return text if text.blank?
 
-    @mapping.each { |placeholder, name| text = text.gsub(placeholder, name) }
+    @mapping.each { |placeholder, name| text = text.gsub(placeholder) { name } }
     text
   end
 

--- a/app/services/name_redactor.rb
+++ b/app/services/name_redactor.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+# Redacts real names of people associated with a kid (kid, guardian,
+# teachers, mentors, admins, the kid's school's principals) from free text
+# before it is sent to a third-party AI provider, matching misspellings and
+# initials ("M." for "Mira") via Jaro-Winkler similarity. Each matched person
+# gets a unique, stable placeholder so #rehydrate can later reverse the
+# substitution unambiguously (e.g. two different mentors both mentioned in
+# the same text don't collapse into one placeholder). See JournalSummarizer,
+# which redacts the outgoing prompt and rehydrates the AI's response with
+# the same instance/mapping.
+class NameRedactor
+  SIMILARITY_THRESHOLD = 0.92
+  MIN_TOKEN_LENGTH = 3
+
+  # Admin/principal are kid-independent, system-wide lists (every admin is
+  # checked against every kid's text, regardless of whether they're actually
+  # involved with that kid) - the larger a dictionary, the more likely some
+  # entry in it randomly resembles a common German word within fuzzy-match
+  # distance (confirmed during testing against real, redacted production
+  # data: a real admin's surname scored 0.93 against an unrelated, very
+  # common German adjective, well above SIMILARITY_THRESHOLD, and would
+  # have redacted that ordinary word out of every kid's summary system-
+  # wide). Kid/guardian/teacher/mentor are small,
+  # contextually-certain lists (a handful of people actually tied to this
+  # kid) where fuzzy typo tolerance is worth the risk; admin/principal only
+  # get exact (case-insensitive) matches.
+  EXACT_MATCH_ROLES = %i[admin principal].freeze
+
+  # scans the whole text for word-shaped spans directly (letters plus
+  # interior apostrophes for names like "O'Brien", with an optional single
+  # trailing period) instead of pre-splitting on whitespace: real journal
+  # text glues names to neighbouring words with all kinds of punctuation and
+  # no space (confirmed against real production data - patterns like
+  # "Peter-Mira" [hyphen], "Schwierigkeiten:Mira" [colon], "dich/Mira"
+  # [slash], "vorgelesen habe.Mira" [missing space after a full stop]), and
+  # enumerating every separator character as a split point is a losing
+  # game. Scanning for words directly sidesteps that: only \p{L} runs (plus
+  # the apostrophe glue) are ever candidates, so any other character -
+  # hyphen, colon, slash, comma, parens, Unicode line separators pasted
+  # from rich text - naturally acts as a boundary and is left untouched.
+  # Hyphens are deliberately NOT part of the word itself even for genuine
+  # compound surnames ("Meier-Müller"): there's no lexical way to tell that
+  # apart from two unrelated words glued together with a hyphen, so it's
+  # split too - each half still matches independently (see
+  # PersonDictionary.name_words, split the same way for symmetry).
+  WORD_PATTERN = /\p{L}+(?:['’]\p{L}+)*\.?/
+
+  ROLE_LABELS = {
+    kid: 'Kind',
+    parent: 'ErziehungsberechtigteR',
+    teacher: 'Lehrperson',
+    mentor: 'Mentor',
+    admin: 'Coach',
+    principal: 'Schulleitung',
+    other: 'Person'
+  }.freeze
+
+  def initialize(kid)
+    @people = PersonDictionary.new(kid).people
+    @placeholders = {} # person key => placeholder
+    @mapping = {} # placeholder => real display name
+    @role_counters = Hash.new(0)
+  end
+
+  # deterministic redaction for a known record (e.g. `teacher.display_name`
+  # in kids/show.md.erb) - no fuzzy matching involved, since the template
+  # already knows exactly whose name it is inserting. Reserve #redact for
+  # genuine free text (notes, journal narratives) where a name could appear
+  # anywhere, misspelled, or as an initial - fuzzy-matching *known* fields
+  # instead of substituting them directly is what caused static template
+  # text ("Kind", "Coach" - the labels, not values) to collide with real
+  # people who happen to share a name with that vocabulary.
+  def placeholder_for_record(record)
+    return nil if record.nil?
+
+    key = PersonDictionary.key_for(record)
+    person = @people.find { |p| p.key == key } || PersonDictionary.person_for(record)
+    placeholder_for(person)
+  end
+
+  def redact(text)
+    return text if text.blank?
+
+    result = text.gsub(WORD_PATTERN) { redact_match(Regexp.last_match) }
+    # some fields are a free-text snapshot of a "Surname, Prename" string
+    # (e.g. Comment#by) rather than a link to the record, so surname and
+    # prename are matched as two separate word tokens even though they
+    # name the same person - collapse immediately-adjacent repeats of the
+    # same placeholder rather than showing it twice in a row
+    result.gsub(%r{(\[\w+\d+\])(?:[\s,\-:/]+\1)+}, '\1')
+  end
+
+  def rehydrate(text)
+    return text if text.blank?
+
+    @mapping.each { |placeholder, name| text = text.gsub(placeholder, name) }
+    text
+  end
+
+  private
+
+  def redact_match(match_data)
+    match = match_data.to_s
+    has_dot = match.end_with?('.')
+    core = has_dot ? match[0..-2] : match
+    is_initial = core.length == 1 && has_dot
+    return match if is_initial && abbreviation_cluster?(match_data)
+
+    person = best_match(is_initial ? "#{core}." : core)
+    return match unless person
+
+    "#{placeholder_for(person)}#{initial_suffix(has_dot, is_initial)}"
+  end
+
+  # a single letter followed by a period is an initial ("M.") - the only
+  # case where the trailing period is actually part of the match itself,
+  # rather than end-of-sentence punctuation that happened to get swept up
+  def initial_suffix(has_dot, is_initial)
+    has_dot && !is_initial ? '.' : ''
+  end
+
+  # German has several multi-part abbreviations built from single-letter
+  # initials ("z. B." = zum Beispiel, "u. a." = unter anderem, "i. d. R." =
+  # in der Regel) that are lexically indistinguishable from a real person's
+  # initial in isolation. The disambiguating signal is that they cluster: a
+  # genuine name-initial normally stands alone, while these idioms always
+  # have another lone letter-dot token immediately before or after. Erring
+  # towards leaving a name un-redacted in this narrow case beats mangling
+  # common German abbreviations throughout every summary.
+  def abbreviation_cluster?(match_data)
+    match_data.pre_match.match?(/\p{L}\.\s*\z/) || match_data.post_match.match?(/\A\s*\p{L}\./)
+  end
+
+  def best_match(word)
+    return match_by_initial(word) if word.match?(/\A\p{Lu}\.\z/)
+    return nil if word.length < MIN_TOKEN_LENGTH
+
+    match_by_similarity(word)
+  end
+
+  def match_by_initial(word)
+    @people.find { |person| person.initial_tokens.any? { |t| t.casecmp?(word) } }
+  end
+
+  def match_by_similarity(word)
+    scored = @people.filter_map { |person| score_person(person, word) }
+    scored.select { |_person, score| score >= SIMILARITY_THRESHOLD }.max_by { |_person, score| score }&.first
+  end
+
+  def score_person(person, word)
+    if EXACT_MATCH_ROLES.include?(person.role)
+      return [person, 1.0] if person.name_tokens.any? { |t| t.casecmp?(word) }
+
+      return nil
+    end
+
+    best_score = person.name_tokens.map { |t| JaroWinkler.similarity(word.downcase, t.downcase) }.max
+    [person, best_score] if best_score
+  end
+
+  def placeholder_for(person)
+    @placeholders[person.key] ||= begin
+      @role_counters[person.role] += 1
+      placeholder = "[#{ROLE_LABELS.fetch(person.role)}#{@role_counters[person.role]}]"
+      @mapping[placeholder] = person.display_name
+      placeholder
+    end
+  end
+end

--- a/app/services/person_dictionary.rb
+++ b/app/services/person_dictionary.rb
@@ -120,12 +120,14 @@ class PersonDictionary
       self.class.person_for(@kid.third_teacher, :teacher),
       self.class.person_for(@kid.mentor, :mentor),
       self.class.person_for(@kid.secondary_mentor, :mentor),
-      *@kid.journals.map { |journal| self.class.person_for(journal.mentor, :mentor) },
-      *@kid.first_year_assessments.flat_map do |a|
+      *@kid.journals.includes(:mentor).map { |journal| self.class.person_for(journal.mentor, :mentor) },
+      *@kid.first_year_assessments.includes(:teacher, :mentor).flat_map do |a|
         [self.class.person_for(a.teacher, :teacher), self.class.person_for(a.mentor, :mentor)]
       end,
-      *@kid.termination_assessments.map { |a| self.class.person_for(a.teacher, :teacher) },
-      *@kid.relation_logs.map { |log| self.class.person_for(log.user, RELATION_LOG_ROLES.fetch(log.role, :admin)) },
+      *@kid.termination_assessments.includes(:teacher).map { |a| self.class.person_for(a.teacher, :teacher) },
+      *@kid.relation_logs.includes(:user).map do |log|
+        self.class.person_for(log.user, RELATION_LOG_ROLES.fetch(log.role, :admin))
+      end,
       *Admin.all.map { |admin| self.class.person_for(admin, :admin) },
       *@kid.school&.principals&.map { |principal| self.class.person_for(principal, :principal) }
     ]
@@ -148,7 +150,7 @@ class PersonDictionary
 
   def guardian_words
     @kid.parent.split(GUARDIAN_DELIMITER).flat_map { |part| part.split(/[\s-]+/) }.reject do |word|
-      word.blank? || GUARDIAN_STOPWORDS.include?(word.downcase)
+      word.blank? || GUARDIAN_STOPWORDS.include?(word.downcase) || NAME_PARTICLES.include?(word.downcase)
     end
   end
 end

--- a/app/services/person_dictionary.rb
+++ b/app/services/person_dictionary.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# Builds the list of real people who could plausibly be mentioned by name in
+# a kid's free text (journal notes, assessment narratives, comments), for
+# NameRedactor to match against. Built fresh from the DB on every call - see
+# NameRedactor for why nothing here is persisted.
+class PersonDictionary
+  # dictionary tokens shorter than this are excluded: short tokens (2-letter
+  # German prepositions like "de"/"in") fuzzy-match all kinds of unrelated
+  # words via Jaro-Winkler and cause widespread false-positive redaction
+  MIN_NAME_TOKEN_LENGTH = 3
+
+  # kids.parent is free text, not a clean "Firstname Lastname" field: real
+  # production data (checked via Kid.pluck(:parent)) contains multiple
+  # guardians separated by various delimiters ("Anna und Peter Muster",
+  # "Lisa Beispiel & Karim Beispiel", "Tom Muster (Mutter) / Jan Muster
+  # (Vater)"), inconsistent name order, and embedded free-text remarks
+  # ("wohnt in Musterhausen", "Kommunikation ... über die Mutter, lea"). There
+  # is no reliable way to pair first/last names or tell how many distinct
+  # people are named, so every word is treated as a candidate token for one
+  # composite "guardian" dictionary entry, after stripping connectors and
+  # common role/annotation words that would otherwise cause false-positive
+  # matches (e.g. "Mutter", "und") - erring towards over-redaction rather
+  # than missing a real name is the safe direction for this feature.
+  GUARDIAN_DELIMITER = %r{[,&+/()]}
+  GUARDIAN_STOPWORDS = %w[
+    und oder sowie bzw mutter vater eltern familie kommunikation wohnt
+    wohnhaft jetzt eher ueber über die der das von in an bei fuer für mit
+    com tel telefon email mail adresse kontakt
+  ].freeze
+
+  # name particles common in European surnames ("von Muster", "van Beispiel",
+  # "de la Muster") are also ordinary words in running German text ("von" =
+  # "of/from") - excluded as standalone dictionary tokens so they can't
+  # exact-match the everyday word everywhere. The rest of a multi-word name
+  # (e.g. "Muster") stays a fine match anchor on its own.
+  NAME_PARTICLES = %w[von van der zu de und la].freeze
+
+  RELATION_LOG_ROLES = {
+    'mentor' => :mentor, 'secondary_mentor' => :mentor,
+    'teacher' => :teacher, 'secondary_teacher' => :teacher, 'third_teacher' => :teacher,
+    'admin' => :admin
+  }.freeze
+
+  ROLE_FOR_CLASS = {
+    'Kid' => :kid, 'Mentor' => :mentor, 'Teacher' => :teacher, 'Admin' => :admin, 'Principal' => :principal
+  }.freeze
+
+  Person = Struct.new(:key, :role, :display_name, :name_tokens, :initial_tokens, keyword_init: true)
+
+  # real (User/Kid) record -> dictionary key, e.g. "User_42" - shared between
+  # #people (building the full list) and NameRedactor#placeholder_for_record
+  # (looking up one specific record for deterministic, non-fuzzy redaction
+  # of names the template inserts directly, e.g. `teacher.display_name`)
+  def self.key_for(record)
+    "#{record.class.base_class}_#{record.id}"
+  end
+
+  # stateless: does not depend on which kid is being redacted, so it also
+  # serves as a fallback when NameRedactor is asked to redact a record that
+  # isn't already in the kid's dictionary (defensive - should not normally
+  # happen, since every association the template renders is also walked in
+  # #build_people, but better to still redact correctly than to leak)
+  def self.person_for(record, role = nil)
+    return nil if record.nil?
+
+    role ||= ROLE_FOR_CLASS.fetch(record.class.base_class.name, :other)
+    Person.new(
+      key: key_for(record),
+      role: role,
+      display_name: readable_name(record),
+      name_tokens: name_words(record.name) + name_words(record.prename),
+      initial_tokens: [initial(record.prename)].compact
+    )
+  end
+
+  # the AI summary reads as flowing German prose, so rehydrating with the
+  # admin-listing "Nachname, Vorname" format (User/Kid#display_name) would
+  # read unnaturally - use the first name people are actually referred to by
+  def self.readable_name(record)
+    record.prename.presence || record.name
+  end
+
+  # real names can be multi-word (compound surnames, multiple given names) -
+  # splitting into individual word tokens is what lets a single-word mention
+  # in free text ("Sofia") match a multi-word field ("Sofia Elena
+  # Muster"); comparing the word against the whole field as one token
+  # would almost never score high enough
+  def self.name_words(value)
+    return [] if value.blank?
+
+    # split on hyphens too (not just whitespace) so "Meier-Müller" yields
+    # "Meier" and "Müller" as independently matchable tokens - see
+    # NameRedactor::CORE_PATTERN for why free text is tokenized the same way
+    value.split(/[\s-]+/).reject { |w| w.length < MIN_NAME_TOKEN_LENGTH || NAME_PARTICLES.include?(w.downcase) }
+  end
+
+  def self.initial(name)
+    return nil if name.blank?
+
+    "#{name.strip.first}."
+  end
+
+  def initialize(kid)
+    @kid = kid
+  end
+
+  def people
+    @people ||= build_people.compact.uniq(&:key)
+  end
+
+  private
+
+  def build_people
+    [
+      self.class.person_for(@kid, :kid),
+      guardian_person,
+      self.class.person_for(@kid.teacher, :teacher),
+      self.class.person_for(@kid.secondary_teacher, :teacher),
+      self.class.person_for(@kid.third_teacher, :teacher),
+      self.class.person_for(@kid.mentor, :mentor),
+      self.class.person_for(@kid.secondary_mentor, :mentor),
+      *@kid.journals.map { |journal| self.class.person_for(journal.mentor, :mentor) },
+      *@kid.first_year_assessments.flat_map do |a|
+        [self.class.person_for(a.teacher, :teacher), self.class.person_for(a.mentor, :mentor)]
+      end,
+      *@kid.termination_assessments.map { |a| self.class.person_for(a.teacher, :teacher) },
+      *@kid.relation_logs.map { |log| self.class.person_for(log.user, RELATION_LOG_ROLES.fetch(log.role, :admin)) },
+      *Admin.all.map { |admin| self.class.person_for(admin, :admin) },
+      *@kid.school&.principals&.map { |principal| self.class.person_for(principal, :principal) }
+    ]
+  end
+
+  def guardian_person
+    return nil if @kid.parent.blank?
+
+    words = guardian_words
+    initials, names = words.partition { |w| w.match?(/\A\p{Lu}\.\z/) }
+    names = names.select { |w| w.length >= MIN_NAME_TOKEN_LENGTH }
+    return nil if names.empty? && initials.empty?
+
+    # rehydration restores the original field verbatim rather than
+    # reconstructing "the" guardian name, since the field may name more than
+    # one person and there is no reliable way to tell which one matched
+    Person.new(key: 'kid_parent', role: :parent, display_name: @kid.parent, name_tokens: names,
+               initial_tokens: initials)
+  end
+
+  def guardian_words
+    @kid.parent.split(GUARDIAN_DELIMITER).flat_map { |part| part.split(/[\s-]+/) }.reject do |word|
+      word.blank? || GUARDIAN_STOPWORDS.include?(word.downcase)
+    end
+  end
+end

--- a/app/views/kids/show.md.erb
+++ b/app/views/kids/show.md.erb
@@ -1,4 +1,9 @@
-# <%= Kid.model_name.human %>: <%= @kid.display_name %>
+<%
+  redactor = local_assigns[:redactor]
+  name_of = ->(record) { record.nil? ? nil : (redactor ? redactor.placeholder_for_record(record) : record.display_name) }
+  redact = ->(text) { redactor ? redactor.redact(text) : text }
+-%>
+# <%= Kid.model_name.human %>: <%= name_of.(@kid) %>
 
 ## Allgemeine Informationen
 
@@ -18,22 +23,22 @@
 - <%= Kid.human_attribute_name(:parent_country_name) %>: <%= @kid.parent_country_name %>
 <% end -%>
 <% if @kid.note.present? -%>
-- <%= Kid.human_attribute_name(:note) %>: <%= @kid.note %>
+- <%= Kid.human_attribute_name(:note) %>: <%= redact.(@kid.note) %>
 <% end -%>
 <% if @kid.teacher.present? -%>
-- <%= Kid.human_attribute_name(:teacher) %>: <%= @kid.teacher.display_name %>
+- <%= Kid.human_attribute_name(:teacher) %>: <%= name_of.(@kid.teacher) %>
 <% end -%>
 <% if @kid.secondary_teacher.present? -%>
-- <%= Kid.human_attribute_name(:secondary_teacher) %>: <%= @kid.secondary_teacher.display_name %>
+- <%= Kid.human_attribute_name(:secondary_teacher) %>: <%= name_of.(@kid.secondary_teacher) %>
 <% end -%>
 <% if @kid.third_teacher.present? -%>
-- <%= Kid.human_attribute_name(:third_teacher) %>: <%= @kid.third_teacher.display_name %>
+- <%= Kid.human_attribute_name(:third_teacher) %>: <%= name_of.(@kid.third_teacher) %>
 <% end -%>
 <% if @kid.mentor.present? -%>
-- <%= Kid.human_attribute_name(:mentor) %>: <%= @kid.mentor.display_name %>
+- <%= Kid.human_attribute_name(:mentor) %>: <%= name_of.(@kid.mentor) %>
 <% end -%>
 <% if @kid.secondary_active? && @kid.secondary_mentor.present? -%>
-- <%= Kid.human_attribute_name(:secondary_mentor) %>: <%= @kid.secondary_mentor.display_name %>
+- <%= Kid.human_attribute_name(:secondary_mentor) %>: <%= name_of.(@kid.secondary_mentor) %>
 <% end -%>
 
 ## Fachliche Förderbereiche
@@ -110,7 +115,7 @@
 - <%= Kid.human_attribute_name(:goal_24) %>
 <% end -%>
 <% if @kid.goal_1.present? -%>
-- <%= Kid.human_attribute_name(:goal_1) %>: <%= @kid.goal_1 %>
+- <%= Kid.human_attribute_name(:goal_1) %>: <%= redact.(@kid.goal_1) %>
 <% end -%>
 
 ## Überfachliche Förderbereiche
@@ -154,7 +159,7 @@
 - <%= Kid.human_attribute_name(:goal_35) %>
 <% end -%>
 <% if @kid.goal_2.present? -%>
-- <%= Kid.human_attribute_name(:goal_2) %>: <%= @kid.goal_2 %>
+- <%= Kid.human_attribute_name(:goal_2) %>: <%= redact.(@kid.goal_2) %>
 <% end -%>
 
 ## Verlauf
@@ -184,114 +189,114 @@
 <% case record -%>
 <% when Journal -%>
 <% if record.mentor.present? -%>
-- <%= Journal.human_attribute_name(:mentor) %>: <%= record.mentor.display_name %>
+- <%= Journal.human_attribute_name(:mentor) %>: <%= name_of.(record.mentor) %>
 <% end -%>
 <% if record.subject.present? -%>
-- <%= Journal.human_attribute_name(:subject) %>: <%= record.subject %>
+- <%= Journal.human_attribute_name(:subject) %>: <%= redact.(record.subject) %>
 <% end -%>
 <% if record.goal.present? -%>
-- <%= Journal.human_attribute_name(:goal) %>: <%= record.goal %>
+- <%= Journal.human_attribute_name(:goal) %>: <%= redact.(record.goal) %>
 <% end -%>
 <% if record.method.present? -%>
-- <%= Journal.human_attribute_name(:method) %>: <%= record.method %>
+- <%= Journal.human_attribute_name(:method) %>: <%= redact.(record.method) %>
 <% end -%>
 <% if record.outcome.present? -%>
-- <%= Journal.human_attribute_name(:outcome) %>: <%= record.outcome %>
+- <%= Journal.human_attribute_name(:outcome) %>: <%= redact.(record.outcome) %>
 <% end -%>
 <% if record.note.present? -%>
-- <%= Journal.human_attribute_name(:note) %>: <%= record.note %>
+- <%= Journal.human_attribute_name(:note) %>: <%= redact.(record.note) %>
 <% end -%>
 <% if record.comments.any? -%>
 
 #### Kommentare
 
 <% record.comments.sort_by(&:created_at).each do |comment| -%>
-- <%= human_date(comment.created_at) %> – <%= comment.by %>: <%= comment.body %>
+- <%= human_date(comment.created_at) %> – <%= redact.(comment.by) %>: <%= redact.(comment.body) %>
 <% end -%>
 <% end -%>
 <% when Review -%>
 <% if record.attendee.present? -%>
-- <%= Review.human_attribute_name(:attendee) %>: <%= record.attendee %>
+- <%= Review.human_attribute_name(:attendee) %>: <%= redact.(record.attendee) %>
 <% end -%>
 <% if record.reason.present? -%>
-- <%= Review.human_attribute_name(:reason) %>: <%= record.reason %>
+- <%= Review.human_attribute_name(:reason) %>: <%= redact.(record.reason) %>
 <% end -%>
 <% if record.kind.present? -%>
-- <%= Review.human_attribute_name(:kind) %>: <%= record.kind %>
+- <%= Review.human_attribute_name(:kind) %>: <%= redact.(record.kind) %>
 <% end -%>
 <% if record.content.present? -%>
-- <%= Review.human_attribute_name(:content) %>: <%= record.content %>
+- <%= Review.human_attribute_name(:content) %>: <%= redact.(record.content) %>
 <% end -%>
 <% if record.outcome.present? -%>
-- <%= Review.human_attribute_name(:outcome) %>: <%= record.outcome %>
+- <%= Review.human_attribute_name(:outcome) %>: <%= redact.(record.outcome) %>
 <% end -%>
 <% if record.note.present? -%>
-- <%= Review.human_attribute_name(:note) %>: <%= record.note %>
+- <%= Review.human_attribute_name(:note) %>: <%= redact.(record.note) %>
 <% end -%>
 <% when FirstYearAssessment -%>
 <% if record.teacher.present? -%>
-- <%= FirstYearAssessment.human_attribute_name(:teacher) %>: <%= record.teacher.display_name %>
+- <%= FirstYearAssessment.human_attribute_name(:teacher) %>: <%= name_of.(record.teacher) %>
 <% end -%>
 <% if record.mentor.present? -%>
-- <%= FirstYearAssessment.human_attribute_name(:mentor) %>: <%= record.mentor.display_name %>
+- <%= FirstYearAssessment.human_attribute_name(:mentor) %>: <%= name_of.(record.mentor) %>
 <% end -%>
 <% if record.development_teacher.present? || record.development_mentor.present? -%>
 - <%= FirstYearAssessment.human_attribute_name(:development) %>
 <% if record.development_teacher.present? -%>
-  - <%= FirstYearAssessment.human_attribute_name(:development_teacher) %>: <%= record.development_teacher %>
+  - <%= FirstYearAssessment.human_attribute_name(:development_teacher) %>: <%= redact.(record.development_teacher) %>
 <% end -%>
 <% if record.development_mentor.present? -%>
-  - <%= FirstYearAssessment.human_attribute_name(:development_mentor) %>: <%= record.development_mentor %>
+  - <%= FirstYearAssessment.human_attribute_name(:development_mentor) %>: <%= redact.(record.development_mentor) %>
 <% end -%>
 <% end -%>
 <% if record.goals_teacher.present? || record.goals_mentor.present? -%>
 - <%= FirstYearAssessment.human_attribute_name(:goals) %>
 <% if record.goals_teacher.present? -%>
-  - <%= FirstYearAssessment.human_attribute_name(:goals_teacher) %>: <%= record.goals_teacher %>
+  - <%= FirstYearAssessment.human_attribute_name(:goals_teacher) %>: <%= redact.(record.goals_teacher) %>
 <% end -%>
 <% if record.goals_mentor.present? -%>
-  - <%= FirstYearAssessment.human_attribute_name(:goals_mentor) %>: <%= record.goals_mentor %>
+  - <%= FirstYearAssessment.human_attribute_name(:goals_mentor) %>: <%= redact.(record.goals_mentor) %>
 <% end -%>
 <% end -%>
 <% if record.relation_mentor.present? -%>
-- <%= FirstYearAssessment.human_attribute_name(:relation_mentor) %>: <%= record.relation_mentor %>
+- <%= FirstYearAssessment.human_attribute_name(:relation_mentor) %>: <%= redact.(record.relation_mentor) %>
 <% end -%>
 <% if record.motivation.present? -%>
-- <%= FirstYearAssessment.human_attribute_name(:motivation) %>: <%= record.motivation %>
+- <%= FirstYearAssessment.human_attribute_name(:motivation) %>: <%= redact.(record.motivation) %>
 <% end -%>
 <% if record.collaboration.present? -%>
-- <%= FirstYearAssessment.human_attribute_name(:collaboration) %>: <%= record.collaboration %>
+- <%= FirstYearAssessment.human_attribute_name(:collaboration) %>: <%= redact.(record.collaboration) %>
 <% end -%>
 <% if record.improvements.present? -%>
-- <%= FirstYearAssessment.human_attribute_name(:improvements) %>: <%= record.improvements %>
+- <%= FirstYearAssessment.human_attribute_name(:improvements) %>: <%= redact.(record.improvements) %>
 <% end -%>
 <% if record.note.present? -%>
-- <%= FirstYearAssessment.human_attribute_name(:note) %>: <%= record.note %>
+- <%= FirstYearAssessment.human_attribute_name(:note) %>: <%= redact.(record.note) %>
 <% end -%>
 <% when TerminationAssessment -%>
 <% if record.teacher.present? -%>
-- <%= TerminationAssessment.human_attribute_name(:teacher) %>: <%= record.teacher.display_name %>
+- <%= TerminationAssessment.human_attribute_name(:teacher) %>: <%= name_of.(record.teacher) %>
 <% end -%>
 <% if record.development.present? -%>
-- <%= TerminationAssessment.human_attribute_name(:development) %>: <%= record.development %>
+- <%= TerminationAssessment.human_attribute_name(:development) %>: <%= redact.(record.development) %>
 <% end -%>
 <% if record.goals.present? -%>
-- <%= TerminationAssessment.human_attribute_name(:goals) %>: <%= record.goals %>
+- <%= TerminationAssessment.human_attribute_name(:goals) %>: <%= redact.(record.goals) %>
 <% end -%>
 <% if record.goals_reached.present? -%>
-- <%= TerminationAssessment.human_attribute_name(:goals_reached) %>: <%= record.goals_reached %>
+- <%= TerminationAssessment.human_attribute_name(:goals_reached) %>: <%= redact.(record.goals_reached) %>
 <% end -%>
 <% if record.collaboration.present? -%>
-- <%= TerminationAssessment.human_attribute_name(:collaboration) %>: <%= record.collaboration %>
+- <%= TerminationAssessment.human_attribute_name(:collaboration) %>: <%= redact.(record.collaboration) %>
 <% end -%>
 <% if record.improvements.present? -%>
-- <%= TerminationAssessment.human_attribute_name(:improvements) %>: <%= record.improvements %>
+- <%= TerminationAssessment.human_attribute_name(:improvements) %>: <%= redact.(record.improvements) %>
 <% end -%>
 <% if record.note.present? -%>
-- <%= TerminationAssessment.human_attribute_name(:note) %>: <%= record.note %>
+- <%= TerminationAssessment.human_attribute_name(:note) %>: <%= redact.(record.note) %>
 <% end -%>
 <% when RelationLog -%>
-- <%= record.end_at ? 'Entfernt' : 'Zugeordnet' %> als <%= Kid.human_attribute_name(record.role) %>: <%= record.user&.display_name %>
+- <%= record.end_at ? 'Entfernt' : 'Zugeordnet' %> als <%= Kid.human_attribute_name(record.role) %>: <%= name_of.(record.user) %>
 <% end -%>
 
 <% end -%>

--- a/spec/controllers/kids_controller_spec.rb
+++ b/spec/controllers/kids_controller_spec.rb
@@ -32,6 +32,10 @@ describe KidsController do
       it 'does not allow rendering the markdown representation' do
         expect_access_denied { get :show, params: { id: @kid }, format: :md }
       end
+
+      it 'does not allow rendering the redacted markdown representation' do
+        expect_access_denied { get :show, params: { id: @kid, redacted: 'true' }, format: :md }
+      end
     end
 
     context 'show' do
@@ -95,6 +99,18 @@ describe KidsController do
         expect(response.media_type).to eq('text/markdown')
         expect(response.body.index('Lernjournal vom 10.01.2024'))
           .to be < response.body.index('Gesprächsdokumentation vom 20.01.2024')
+      end
+
+      it 'renders a redacted markdown representation when redacted=true is given' do
+        mentor = create(:mentor, name: 'Fischer', prename: 'Lea')
+        create(:journal, kid: @kid, mentor: mentor, subject: 'Lea kam vorbei.')
+
+        get :show, params: { id: @kid, redacted: 'true' }, format: :md
+
+        expect(response).to be_successful
+        expect(response.media_type).to eq('text/markdown')
+        expect(response.body).not_to include('Lea')
+        expect(response.body).to match(/\[Mentor\d+\]/)
       end
     end
 

--- a/spec/services/journal_summarizer_spec.rb
+++ b/spec/services/journal_summarizer_spec.rb
@@ -81,6 +81,26 @@ describe JournalSummarizer do
       expect { described_class.new(kid).call }.to raise_error(described_class::Error, /keine Zusammenfassung/)
     end
 
+    it 'raises an error when the response body is not valid JSON' do
+      stub_ai_response(body: 'not json')
+      expect { described_class.new(kid).call }.to raise_error(described_class::Error, /nicht gelesen/)
+    end
+
+    it 'raises an error when the connection is refused' do
+      allow(Net::HTTP).to receive(:start).and_raise(Errno::ECONNREFUSED)
+      expect { described_class.new(kid).call }.to raise_error(described_class::Error, /fehlgeschlagen/)
+    end
+
+    it 'raises an error when the connection is reset' do
+      allow(Net::HTTP).to receive(:start).and_raise(Errno::ECONNRESET)
+      expect { described_class.new(kid).call }.to raise_error(described_class::Error, /fehlgeschlagen/)
+    end
+
+    it 'raises an error when the connection closes abruptly' do
+      allow(Net::HTTP).to receive(:start).and_raise(EOFError)
+      expect { described_class.new(kid).call }.to raise_error(described_class::Error, /fehlgeschlagen/)
+    end
+
     it 'includes cancelled journals in the prompt, marked as cancelled' do
       create(:cancelled_journal, kid: kid, held_at: Date.new(2024, 5, 1))
       stub_ai_response(body: { choices: [{ message: { content: 'ok' } }] }.to_json)

--- a/spec/services/journal_summarizer_spec.rb
+++ b/spec/services/journal_summarizer_spec.rb
@@ -122,4 +122,32 @@ describe JournalSummarizer do
       end
     end
   end
+
+  context 'with a single known mentor to redact' do
+    let(:journal_mentor) { create(:mentor, name: 'Fischer', prename: 'Lea') }
+
+    before { create(:journal, kid: kid, mentor: journal_mentor) }
+
+    it 'redacts the mentor name from the outgoing prompt' do
+      stub_ai_response(body: { choices: [{ message: { content: 'ok' } }] }.to_json)
+      described_class.new(kid).call
+      expect(posted_http).to have_received(:post) do |_uri, body, _headers|
+        prompt = JSON.parse(body)['messages'].first['content']
+        expect(prompt).not_to include('Lea')
+        expect(prompt).to match(/\[Mentor\d+\]/)
+      end
+    end
+
+    it 'rehydrates a placeholder in the AI response back to the real name' do
+      http_double = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:start).and_yield(http_double)
+      allow(http_double).to receive(:post) do |_uri, body, _headers|
+        placeholder = JSON.parse(body)['messages'].first['content'][/\[Mentor\d+\]/]
+        content = { choices: [{ message: { content: "Bericht über #{placeholder}." } }] }.to_json
+        instance_double(Net::HTTPSuccess, code: '200', body: content, is_a?: true)
+      end
+
+      expect(described_class.new(kid).call).to eq('Bericht über Lea.')
+    end
+  end
 end

--- a/spec/services/name_redactor_spec.rb
+++ b/spec/services/name_redactor_spec.rb
@@ -80,6 +80,13 @@ describe NameRedactor do
       expect(redactor.rehydrate(redacted)).to eq('Anna a Marca de Muster // Beispiel Fritz (wohnt in Musterhausen) rief an.')
     end
 
+    it 'does not treat a guardian name particle as a standalone match token' do
+      kid.update!(parent: 'Anna van Muster')
+
+      result = described_class.new(kid).redact('Wir haben die Reise dann van Fahrt genannt.')
+      expect(result).to eq('Wir haben die Reise dann van Fahrt genannt.')
+    end
+
     it 'redacts teachers including the third teacher, with distinct placeholders' do
       teacher = create(:teacher, name: 'Berger', prename: 'Anna')
       third_teacher = create(:teacher, name: 'Keller', prename: 'Tom')
@@ -177,6 +184,13 @@ describe NameRedactor do
     it 'returns text unchanged when no placeholders were ever produced' do
       redactor = described_class.new(kid)
       expect(redactor.rehydrate('Ein normaler Satz.')).to eq('Ein normaler Satz.')
+    end
+
+    it 'restores a guardian name containing a literal backslash without mangling it' do
+      kid.update!(parent: 'Anna \\1 Muster')
+      redactor = described_class.new(kid)
+      redacted = redactor.redact('Anna hat angerufen.')
+      expect(redactor.rehydrate(redacted)).to eq('Anna \\1 Muster hat angerufen.')
     end
   end
 end

--- a/spec/services/name_redactor_spec.rb
+++ b/spec/services/name_redactor_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe NameRedactor do
+  let(:kid) { create(:kid, name: 'Muster', prename: 'Mira', parent: 'Nicole Muster') }
+
+  describe '#redact' do
+    it 'replaces the kid\'s own first name with a unique placeholder' do
+      expect(described_class.new(kid).redact('Mira war heute motiviert.'))
+        .to eq('[Kind1] war heute motiviert.')
+    end
+
+    it 'catches a misspelled first name via fuzzy matching' do
+      expect(described_class.new(kid).redact('Miera war heute motiviert.'))
+        .to eq('[Kind1] war heute motiviert.')
+    end
+
+    it 'catches an initial for a known name' do
+      expect(described_class.new(kid).redact('M. war heute motiviert.'))
+        .to eq('[Kind1] war heute motiviert.')
+    end
+
+    it 'does not treat "z. B." (zum Beispiel) as an initial, even when a real person shares the letter' do
+      admin = create(:admin, name: 'Steiner', prename: 'Timon')
+
+      result = described_class.new(kid).redact('Nur wenn es z. B. um die Familie geht.')
+      expect(result).to eq('Nur wenn es z. B. um die Familie geht.')
+      admin.destroy
+    end
+
+    it 'does not treat "i. d. R." as initials' do
+      result = described_class.new(kid).redact('Das ist i. d. R. der Fall.')
+      expect(result).to eq('Das ist i. d. R. der Fall.')
+    end
+
+    it 'does not touch unrelated words' do
+      expect(described_class.new(kid).redact('Wir haben heute Bruchrechnen geübt.'))
+        .to eq('Wir haben heute Bruchrechnen geübt.')
+    end
+
+    it 'redacts the guardian name' do
+      expect(described_class.new(kid).redact('Nicole hat angerufen.'))
+        .to eq('[ErziehungsberechtigteR1] hat angerufen.')
+    end
+
+    it 'redacts both guardians when kids.parent names two people separated by "und"' do
+      kid.update!(parent: 'Anna und Peter Muster')
+
+      result = described_class.new(kid).redact('Anna hat angerufen, Peter war auch dabei, Muster wollte das wissen.')
+      expect(result).not_to include('Anna')
+      expect(result).not_to include('Peter')
+      expect(result).not_to include('Muster')
+      expect(result).to include('[ErziehungsberechtigteR1]')
+    end
+
+    it 'redacts guardians separated by a slash with role annotations in parentheses' do
+      kid.update!(name: 'Keller', prename: 'Noah', parent: 'Lisa Beispiel (Mutter) / Tom Beispiel (Vater)')
+
+      result = described_class.new(kid).redact('Lisa rief an, Tom war informiert. Die Mutter kam vorbei.')
+      expect(result).not_to include('Lisa')
+      expect(result).not_to include('Tom')
+      # "Mutter" is a role annotation, not a name, and must not itself become
+      # a redaction trigger word (it would falsely flag it elsewhere)
+      expect(result).to include('Mutter')
+    end
+
+    it 'redacts an initial-only guardian mention like "E. + E. Beispiel"' do
+      kid.update!(parent: 'E. + E. Beispiel')
+
+      result = described_class.new(kid).redact('E. hat sich gemeldet. Beispiel war einverstanden.')
+      expect(result).not_to include('Beispiel')
+      expect(result).to include('[ErziehungsberechtigteR1]')
+    end
+
+    it 'rehydrates a guardian placeholder with the original, unparsed field value' do
+      kid.update!(parent: 'Anna a Marca de Muster // Beispiel Fritz (wohnt in Musterhausen)')
+      redactor = described_class.new(kid)
+      redacted = redactor.redact('Beispiel rief an.')
+      expect(redactor.rehydrate(redacted)).to eq('Anna a Marca de Muster // Beispiel Fritz (wohnt in Musterhausen) rief an.')
+    end
+
+    it 'redacts teachers including the third teacher, with distinct placeholders' do
+      teacher = create(:teacher, name: 'Berger', prename: 'Anna')
+      third_teacher = create(:teacher, name: 'Keller', prename: 'Tom')
+      kid.update!(teacher: teacher, third_teacher: third_teacher)
+
+      result = described_class.new(kid).redact('Anna und Tom waren beide dabei.')
+      expect(result).to include('[Lehrperson1]')
+      expect(result).to include('[Lehrperson2]')
+      expect(result).not_to include('Anna')
+      expect(result).not_to include('Tom')
+    end
+
+    it 'redacts mentors mentioned only via a journal entry, not the kid\'s current mentor field' do
+      old_mentor = create(:mentor, name: 'Fischer', prename: 'Lea')
+      create(:journal, kid: kid, mentor: old_mentor)
+
+      expect(described_class.new(kid).redact('Lea hat mit ihr gerechnet.'))
+        .to eq('[Mentor1] hat mit ihr gerechnet.')
+    end
+
+    it 'redacts admins even when not assigned to this kid' do
+      admin = create(:admin, name: 'Wyss', prename: 'Sara')
+
+      expect(described_class.new(kid).redact('Sara war zu Besuch.'))
+        .to eq('[Coach1] war zu Besuch.')
+    end
+
+    it 'redacts principals of the kid\'s own school but not principals of other schools' do
+      school = create(:school)
+      other_school = create(:school)
+      kid.update!(school: school)
+      create(:principal, name: 'Huber', prename: 'Peter', schools: [school])
+      create(:principal, name: 'Meier', prename: 'Karin', schools: [other_school])
+
+      result = described_class.new(kid).redact('Peter und Karin kamen vorbei.')
+      expect(result).to include('[Schulleitung1]')
+      expect(result).to include('Karin')
+    end
+
+    it 'assigns the same placeholder to repeated mentions of the same person' do
+      result = described_class.new(kid).redact('Mira mag Mira gern.')
+      expect(result).to eq('[Kind1] mag [Kind1] gern.')
+    end
+
+    it 'redacts every word of a compound multi-word name, not just the words it shares with the guardian' do
+      kid.update!(name: 'De La Fuente Muster', prename: 'Sofia Elena', parent: 'Carlos De La Fuente Beispiel')
+
+      result = described_class.new(kid).redact('De La Fuente Muster ist Sofia Elena.')
+      expect(result).not_to include('Fuente')
+      expect(result).not_to include('Muster')
+      expect(result).not_to include('Sofia')
+      expect(result).not_to include('Elena')
+    end
+
+    it 'collapses immediately-adjacent repeats of the same placeholder' do
+      admin = create(:admin, name: 'Wenger', prename: 'Rahel')
+
+      expect(described_class.new(kid).redact('Wenger, Rahel hat angerufen.')).to eq('[Coach1] hat angerufen.')
+      expect(described_class.new(kid).redact('Wenger Rahel hat angerufen.')).to eq('[Coach1] hat angerufen.')
+      admin.destroy
+    end
+
+    it 'does not collapse two separate mentions with a real word between them' do
+      result = described_class.new(kid).redact('Mira und nochmals Mira waren da.')
+      expect(result).to eq('[Kind1] und nochmals [Kind1] waren da.')
+    end
+  end
+
+  describe '#placeholder_for_record' do
+    it 'returns a deterministic placeholder without any fuzzy text matching' do
+      teacher = create(:teacher, name: 'Brunner', prename: 'Timo')
+      kid.update!(teacher: teacher)
+
+      expect(described_class.new(kid).placeholder_for_record(teacher)).to eq('[Lehrperson1]')
+    end
+
+    it 'returns nil for a nil record' do
+      expect(described_class.new(kid).placeholder_for_record(nil)).to be_nil
+    end
+
+    it 'still redacts a record that is not part of the pre-built dictionary, as a safety net' do
+      other_kid = create(:kid, name: 'Fremd', prename: 'Anderes')
+
+      expect(described_class.new(kid).placeholder_for_record(other_kid)).to eq('[Kind1]')
+    end
+  end
+
+  describe '#rehydrate' do
+    it 'restores the real name for a placeholder produced by redact' do
+      redactor = described_class.new(kid)
+      redacted = redactor.redact('Mira war heute motiviert.')
+      expect(redactor.rehydrate(redacted)).to eq('Mira war heute motiviert.')
+    end
+
+    it 'returns text unchanged when no placeholders were ever produced' do
+      redactor = described_class.new(kid)
+      expect(redactor.rehydrate('Ein normaler Satz.')).to eq('Ein normaler Satz.')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- `JournalSummarizer` sent the kid's full markdown profile (names, journal notes, assessment narratives) verbatim to a third-party LLM; real names are now redacted from the outgoing prompt and the AI's response is rehydrated back to real names before being stored/shown to admins.
- Structured name fields (kid, teachers, mentors, relation log users) are substituted deterministically at render time via `NameRedactor#placeholder_for_record` - the template already knows exactly which record it's inserting, so no fuzzy matching/ambiguity there.
- Free text (notes, journal narratives, comments) is fuzzy-matched (Jaro-Winkler) against a per-kid dictionary of real names built by `PersonDictionary` (kid, guardian, teachers, mentors, admins, the kid's school's principals), catching misspellings and initials like "M." for "Mira".
- Adds a `redacted=true` param on the existing admin-only `/kids/:id.md` markdown export to preview exactly what would be sent to the AI, without triggering an actual call.

## Validation
Redaction logic was validated against a full pull of production data (redaction-only, no AI calls made against real kids in bulk) to catch real-world edge cases beyond synthetic seed data, including:
- Multi-word/compound names (e.g. multi-word surnames and given names)
- Guardian fields naming multiple people with inconsistent delimiters (`&`, `/`, `und`, parenthetical role annotations)
- Names glued to neighbouring words by punctuation with no space (hyphen/colon/slash, missing space after a period)
- German multi-part abbreviations ("z. B.", "i. d. R.") that are lexically identical to a name-initial in isolation - disambiguated via a clustering heuristic rather than an abbreviation list
- System-wide dictionaries (admins/principals) require exact matches only, since fuzzy-matching a large kid-independent list against common German vocabulary produced false positives (a real admin's surname coincidentally scored above threshold against an unrelated common word)

## Test plan
- [x] `bundle exec rspec spec/services/name_redactor_spec.rb spec/services/journal_summarizer_spec.rb spec/controllers/kids_controller_spec.rb` - 73 examples, 0 failures
- [x] Manually verified `JournalSummarizer#call` end-to-end against a real kid record (local dev, real AI provider) - redacted prompt sent, response correctly rehydrated with real names
- [x] Ran a full-scale audit script (no AI calls) across all active kids comparing the redacted markdown output against each kid's own `PersonDictionary`-derived name list to check for leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-generated journal summaries for children, with options to create or regenerate summaries from the journal view.
  * Added configurable AI provider settings and custom summary prompts.
  * Added privacy-focused redaction for names in exported Markdown and AI requests.
  * Added administrator-only Markdown exports and journal summary generation.
* **Security**
  * AI access tokens are encrypted and retained when blank values are submitted.
* **Bug Fixes**
  * Summaries now indicate when newer journal entries are available.
  * Markdown rendering safely escapes embedded HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->