### PR TITLE
Add site-wide toggle to enable/disable AI features

### DIFF
--- a/app/controllers/journal_summaries_controller.rb
+++ b/app/controllers/journal_summaries_controller.rb
@@ -5,6 +5,7 @@ class JournalSummariesController < ApplicationController
     @kid = Kid.find(params[:kid_id])
     authorize! :read, @kid
     raise CanCan::AccessDenied unless current_user.is_a?(Admin)
+    raise CanCan::AccessDenied unless @site.ai_features_enabled?
 
     @kid.update!(journal_summary: JournalSummarizer.new(@kid).call, journal_summary_generated_at: Time.zone.now)
     redirect_to kid_path(@kid), notice: t('flash.journal_summary_generated')

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -40,7 +40,7 @@ class SitesController < ApplicationController
                term_collection_start term_collection_end
                comment_bcc notifications_default_email teachers_can_access_reviews
                kids_schedule_hourly terms_of_use_content
-               title css ai_api_base_url ai_api_token ai_model ai_summary_prompt]
+               title css ai_features_enabled ai_api_base_url ai_api_token ai_model ai_summary_prompt]
     )
     permitted.delete(:ai_api_token) if permitted[:ai_api_token].blank?
     permitted

--- a/app/views/kids/_show.html.haml
+++ b/app/views/kids/_show.html.haml
@@ -154,7 +154,7 @@
   - if can?(:create, @cancan_journal)
     =link_to 'Neues Lernjournal', new_kid_journal_path(@kid), class: 'btn btn-default pull-right'
 
-- if current_user.is_a?(Admin) && @kid.journals.any?
+- if @site.ai_features_enabled? && current_user.is_a?(Admin) && @kid.journals.any?
   .panel.panel-default
     .panel-heading
       %h4 KI-Zusammenfassung

--- a/app/views/sites/_form.html.haml
+++ b/app/views/sites/_form.html.haml
@@ -20,6 +20,7 @@
   = form.input :teachers_can_access_reviews
   = form.input :kids_schedule_hourly
 
+  = form.input :ai_features_enabled
   = form.input :ai_api_base_url, hint: 'OpenAI-kompatible Basis-URL'
   - token_hint = 'Das Feld zeigt den gespeicherten Token nicht an. Leer lassen, um den bestehenden Token zu behalten.'
   = form.input :ai_api_token, as: :string, input_html: { value: '', placeholder: @site.ai_api_token.present? ? '••••••••' : nil }, hint: token_hint

--- a/config/locales/future_kids.de.yml
+++ b/config/locales/future_kids.de.yml
@@ -268,6 +268,7 @@ de:
         kids_schedule_hourly: Stundenplan aktivieren
         terms_of_use_content: Nutzungsbedingungen
         title: Titel des Browsertabs
+        ai_features_enabled: "KI Nutzung erlauben"
         ai_api_base_url: "KI-Anbieter: API Basis-URL"
         ai_api_token: "KI-Anbieter: API-Token"
         ai_model: "KI-Anbieter: Modell"

--- a/db/migrate/20260719160153_add_ai_features_enabled_to_sites.rb
+++ b/db/migrate/20260719160153_add_ai_features_enabled_to_sites.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAiFeaturesEnabledToSites < ActiveRecord::Migration[8.1]
+  def change
+    add_column :sites, :ai_features_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -827,7 +827,8 @@ CREATE TABLE public.sites (
     ai_api_token character varying,
     ai_model character varying,
     ai_api_base_url character varying,
-    ai_summary_prompt text
+    ai_summary_prompt text,
+    ai_features_enabled boolean DEFAULT false NOT NULL
 );
 
 
@@ -1518,6 +1519,7 @@ ALTER TABLE ONLY public.mentor_matchings
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260719160153'),
 ('20260719100000'),
 ('20260717094503'),
 ('20260717085835'),

--- a/spec/controllers/journal_summaries_controller_spec.rb
+++ b/spec/controllers/journal_summaries_controller_spec.rb
@@ -6,6 +6,7 @@ describe JournalSummariesController do
   let(:kid) { create(:kid) }
 
   before do
+    Site.load.update!(ai_features_enabled: true)
     create(:journal, kid: kid)
     sign_in create(:admin)
   end
@@ -29,6 +30,14 @@ describe JournalSummariesController do
       expect(kid.reload.journal_summary).to be_nil
       expect(response).to redirect_to(kid_path(kid))
       expect(flash[:alert]).to eq('boom')
+    end
+  end
+
+  context 'when ai features are disabled' do
+    before { Site.load.update!(ai_features_enabled: false) }
+
+    it 'denies generating a summary' do
+      expect_access_denied { post :create, params: { kid_id: kid.id } }
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds `Site#ai_features_enabled` (boolean, default `false`) to gate all AI functionality centrally
- The "KI-Zusammenfassung" (AI journal summary) panel on the kid page is only shown when the flag is enabled
- `JournalSummariesController#create` denies the request when the flag is off, so the feature can't be triggered directly even with the UI hidden
- Toggle exposed in site settings form

## Test plan
- [x] `bundle exec rspec` — 687 examples, 0 failures
- [x] Added/updated specs covering enabled and disabled states in `journal_summaries_controller_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a site setting to enable or disable AI features.
  * AI summary generation is now available only when AI features are enabled.
  * Added the AI feature setting to site administration forms.

* **Bug Fixes**
  * Prevented AI summary sections and generation when the feature is disabled.

* **Tests**
  * Added coverage for blocked summary generation when AI features are turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->