### PR TITLE
Remove i18n_rails_helpers gem, port helpers locally

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'countries'
 gem 'country_select'
 gem 'devise'
 gem 'google-cloud-storage', require: false
-gem 'i18n_rails_helpers'
 gem 'image_processing'
 gem 'pg'
 gem 'rack-attack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,8 +99,6 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     bigdecimal (4.1.2)
-    bootsnap (1.25.0)
-      msgpack (~> 1.5)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -267,9 +265,6 @@ GEM
     htmlentities (4.4.2)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    i18n_rails_helpers (2.1.0)
-      bootsnap
-      rails (>= 6.0.0)
     image_processing (2.0.3)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
@@ -317,7 +312,6 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.4)
     multi_json (1.21.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
@@ -610,7 +604,6 @@ DEPENDENCIES
   factory_bot_rails
   google-cloud-storage
   haml-rails
-  i18n_rails_helpers
   image_processing
   importmap-rails
   jaro_winkler

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -269,4 +269,266 @@ module ApplicationHelper
 
     d
   end
+
+  # Returns translated name for the given +attribute+.
+  #
+  # If no +model+ is given, it uses the controller name to guess the model by
+  # singularize it.
+  #
+  # Example:
+  #   t_attr('first_name', Patient) => 'Vorname'
+  #   t_attr('first_name')          => 'Vorname' # when called in patients_controller views
+  #
+  def t_attr(attribute, model = nil)
+    model ||= controller_name.classify.constantize
+    model.human_attribute_name(attribute)
+  end
+
+  # Returns translated name for the given +model+.
+  #
+  # If no +model+ is given, it uses the controller name to guess the model by
+  # singularize it. +model+ can be both a class or an actual instance.
+  #
+  # Example:
+  #   t_model(Account)     => 'Konto'
+  #   t_model(Account.new) => 'Konto'
+  #   t_model              => 'Konto' # when called in patients_controller views
+  #
+  def t_model(model = nil)
+    return model.model_name.human if model.is_a? ActiveModel::Naming
+    return model.class.model_name.human if model.class.is_a? ActiveModel::Naming
+    model_key = if model.is_a? Class
+                  model.name.underscore
+                elsif model.nil?
+                  controller_name.singularize
+                else
+                  model.class.name.underscore
+                end
+    I18n.t("activerecord.models.#{model_key}")
+  end
+
+  # Returns translated title for current +action+ on +model+.
+  #
+  # If no +action+ is given, it uses the current action.
+  #
+  # If no +model+ is given, it uses the controller name to guess the model by
+  # singularize it. +model+ can be both a class or an actual instance.
+  #
+  # The translation file comming with the plugin supports the following actions
+  # by default: index, edit, show, new, delete
+  #
+  # You may provide controller specific titles in the translation file. The keys
+  # should have the following format:
+  #
+  #   #{controller_name}.#{action}.title
+  #
+  # Example:
+  #   t_title('new', Account) => 'Konto anlegen'
+  #   t_title('delete')       => 'Konto löschen' # when called in accounts_controller views
+  #   t_title                 => 'Konto ändern'  # when called in accounts_controller edit view
+  #
+  def t_title(action = nil, model = nil)
+    model_key = model&.model_name&.i18n_key || model&.class&.model_name&.i18n_key ||
+      controller_name.underscore
+    I18n.t("#{model_key}.#{action || action_name}.title",
+      default: [:"crud.title.#{action || action_name}"], model: t_model(model))
+  end
+  alias :t_crud :t_title
+
+  # Returns translated string for current +action+.
+  #
+  # If no +action+ is given, it uses the current action.
+  #
+  # The translation file comes with the plugin supports the following actions
+  # by default: index, edit, show, new, delete, back, next, previous
+  #
+  # Example:
+  #   t_action('delete')        => 'Löschen'
+  #   t_action                  => 'Ändern'  # when called in an edit view
+  #
+  def t_action(action = nil, model = nil)
+    I18n.t("crud.action.#{action || action_name}", model: t_model(model))
+  end
+
+  # Returns translated deletion confirmation for +record+.
+  #
+  # It uses +record+.to_s in the message.
+  #
+  # Example:
+  #   t_confirm_delete(@account) => 'Konto Kasse wirklich löschen'
+  #
+  def t_confirm_delete(record)
+    I18n.t('messages.confirm_delete', model: t_model(record), record: record.to_s)
+  end
+
+  # Returns translated drop down field prompt for +model+.
+  #
+  # If no +model+ is given, it tries to guess it from the controller.
+  #
+  # Example:
+  #   t_select_prompt(Account) => 'Konto auswählen'
+  #
+  def t_select_prompt(model = nil)
+    I18n.t('messages.select_prompt', model: t_model(model))
+  end
+
+  # Returns translated identifier
+  def t_page_head
+    if params[:id] && resource
+      "#{t_title} #{resource}"
+    else
+      t_title
+    end
+  end
+
+  # CRUD helpers
+  def action_to_icon(action)
+    case action.to_s
+    when 'new'
+      "plus"
+    when 'show'
+      "eye-open"
+    when 'edit'
+      "edit"
+    when 'delete', 'destroy'
+      "trash"
+    when "index", "list"
+      "list-alt"
+    when "update"
+      "refresh"
+    when "copy"
+      "repeat"
+    else
+      action
+    end
+  end
+
+  def icon_link_to(action, url = nil, options = {})
+    classes = []
+    if class_options = options.delete(:class)
+      classes << class_options.split(' ')
+    end
+
+    classes << 'list-group-item'
+
+    if action.is_a? Symbol
+      url ||= {:action => action}
+      title = t_action(action)
+    else
+      title = action
+    end
+
+    icon = options.delete(:icon)
+    icon ||= action
+
+    type = options.delete(:type)
+    classes << "btn-#{type}" unless type.blank?
+
+    options.merge!(:class => classes.join(" "))
+    link_to(url_for(url), options) do
+      boot_icon(action_to_icon(icon)) + " " + title
+    end
+  end
+
+  def contextual_link_to(action, resource_or_model = nil, link_options = {})
+    # We don't want to change the passed in link_options
+    options = link_options.dup
+
+    # Handle both symbols and strings
+    action = action.to_sym
+
+    # Resource and Model setup
+    # Use controller name to guess resource or model if not specified
+    case action
+    when :new, :index
+      default_model = controller_name.singularize.camelize.constantize
+      model = resource_or_model || default_model
+      explicit_resource_or_model = default_model != model
+    when :show, :edit, :delete, :destroy
+      default_resource = instance_variable_get("@#{controller_name.singularize}")
+      resource = resource_or_model || default_resource
+      model = resource.class
+      explicit_resource_or_model = default_resource != resource
+    end
+    model_name = model.to_s.underscore
+
+    unless resource_or_model.is_a?(String)
+      # No link if CanCan is used and current user isn't authorized to call this action
+      return if respond_to?(:cannot?) and cannot?(action.to_sym, model)
+    end
+
+    # Option generation
+    case action
+    when :delete, :destroy
+      options.merge!(:confirm => t_confirm_delete(resource), :method => :delete)
+    end
+
+    begin
+      if resource_or_model.is_a?(String)
+        path = resource_or_model
+      else
+        # Path generation
+        case action
+        when :index
+          if explicit_resource_or_model
+            path = polymorphic_path(model)
+          else
+            path = url_for(:action => nil)
+          end
+        when :delete, :destroy
+          if explicit_resource_or_model
+            path = polymorphic_path(resource)
+          else
+            path = url_for(:action => :destroy)
+          end
+        else
+          if explicit_resource_or_model
+            path = polymorphic_path(resource_or_model, :action => action)
+          else
+            path = url_for(:action => action)
+          end
+        end
+      end
+
+      return icon_link_to(action, path, options)
+
+    rescue ActionController::UrlGenerationError
+      # This handles cases where we did exclude crud actions in the routing map.
+    end
+  end
+
+  def contextual_links_for(action = nil, resource_or_model = nil, options = {})
+    # Use current action if not specified
+    action ||= action_name
+
+    # Handle both symbols and strings
+    action = action.to_sym
+
+    actions = []
+    case action
+    when :new, :create
+      actions << :index
+    when :show
+      actions += [:edit, :destroy, :index]
+    when :edit, :update
+      actions += [:show, :destroy, :index]
+    when :index
+      actions << :new
+    end
+
+    links = actions.map{|link_for| contextual_link_to(link_for, resource_or_model, options)}
+
+    return links.join("\n").html_safe
+  end
+
+  def contextual_links(action = nil, resource_or_model = nil, options = {}, &block)
+    content_tag('div', :class => 'list-group') do
+      content = contextual_links_for(action, resource_or_model, options)
+      if block_given?
+        additional_content = capture(&block)
+        content += ("\n" + additional_content).html_safe unless additional_content.nil?
+      end
+      content
+    end
+  end
 end

--- a/app/helpers/bootstrap_helper.rb
+++ b/app/helpers/bootstrap_helper.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+module BootstrapHelper
+  if defined?(SimpleForm)
+    def boot_form_for(object, *args, &block)
+      options = args.extract_options!
+      simple_form_for(object, *(args << options.merge(builder: BootFormBuilder)), &block)
+    end
+  end
+
+  def boot_page_title(action_or_title = nil, model = nil, &block)
+    if block_given?
+      title = capture(&block)
+    else
+      if action_or_title.is_a? String
+        title = action_or_title
+      else
+        action = action_or_title || action_name
+        if action.to_s == 'show' && defined?(resource) && resource.present?
+          title = resource.display_name if resource.respond_to?(:display_name)
+          title ||= resource.to_s
+        else
+          title = t_title(action, model)
+        end
+      end
+    end
+
+    content_for :page_title, title
+    content_tag(:div, :class => 'page-header') do
+      content_tag(:h1, title)
+    end
+  end
+
+  # Icons
+  # =====
+  def boot_icon(type)
+    classes = 'icon icon-%s ' % [type]
+    content_tag(:i, '', :class => classes)
+  end
+
+  # Labels
+  # ======
+  def boot_label(content, type = nil)
+    return "" unless content.present?
+
+    classes = ['label', "label-#{type}"].compact.join(' ')
+    content_tag(:span, content, :class => classes)
+  end
+
+  # Modal
+  # =====
+  def modal_header(title)
+    content_tag(:div, :class => 'modal-header') do
+      content_tag(:button, '&times;'.html_safe, :type => 'button', :class => 'close', 'data-dismiss' => 'modal') +
+      content_tag(:h3, title)
+    end
+  end
+
+  # Messages
+  # ========
+  # Map common rails flash types to bootstrap alert names.
+  def boot_alert_name(type)
+    case type
+    when 'alert'
+      'danger'
+    when 'notice'
+      'info'
+    else
+      type
+    end
+  end
+
+  def boot_alert(*args, &block)
+    if block_given?
+      type = args[0]
+      content = capture(&block)
+    else
+      content = args[0]
+      type    = args[1]
+    end
+
+    type ||= 'info'
+    content_tag(:div, :class => "alert alert-#{boot_alert_name(type)}") do
+      link_to('&times;'.html_safe, '#', :class => 'close', 'data-dismiss' => 'alert') + content
+    end
+  end
+
+  def boot_no_entry_alert
+    boot_alert t('alerts.empty')
+  end
+
+  # Navigation
+  # ==========
+  def boot_nav_header(title, refresh_action = false)
+    if title.is_a? Symbol
+      title = t("#{title}.title")
+    end
+
+    content_tag(:li, :class => 'nav-header') do
+      content = [title]
+      if refresh_action
+        content << content_tag(:button, :type => "submit", :style => 'border: none; background-color: transparent; float: right') do
+          content_tag(:i, "", :class => 'icon-refresh')
+        end
+      end
+
+      content.join("\n").html_safe
+    end
+  end
+
+  def boot_nav_li_link(filter_name, param_value, title = nil, param_name = filter_name, current_value = params[param_name], classes = [], &content)
+    classes << "active" if current_value.to_s == param_value.to_s
+    title ||= param_value
+    title = t("#{filter_name.to_s}.#{title}", :default => title)
+
+    if block_given?
+      content_tag(:li, :class => classes, &content)
+    else
+      content_tag(:li, :class => classes) do
+        url = url_for(params.merge({param_name => param_value}))
+        link_to title, url
+      end
+    end
+  end
+
+  def boot_nav_li_checkbox(filter_name, param_value, title = nil, param_name = filter_name, current_value = params[param_name], classes = [], &content)
+    active = current_value.include? param_value.to_s
+    classes << "active" if active
+
+    title ||= param_value
+    title = t("#{filter_name.to_s}.#{title}", :default => title)
+
+    if block_given?
+      content_tag(:li, :class => classes, &content)
+    else
+      content_tag(:li, :class => classes) do
+        content_tag 'label', :class => 'checkbox' do
+          content = []
+          content << content_tag('input', '', :type => 'checkbox', :checked => active, :name => "#{param_name}[]", :value => param_value)
+          content << title
+
+          content.join("\n").html_safe
+        end
+      end
+    end
+  end
+
+  def boot_nav_filter(name, entries, type = :link)
+    refresh_action = (type == :checkbox)
+
+    content_tag(:ul, :class => ['nav', 'nav-list']) do
+      content = []
+      content << boot_nav_header(name, refresh_action)
+
+      entries.each do |entry|
+        if entry.is_a? Hash
+          title = entry[:title]
+          value = entry[:value]
+        else
+          title = value = entry
+        end
+
+        case type
+        when :link
+          content << boot_nav_li_link(name, value, title)
+        when :checkbox
+          content << boot_nav_li_checkbox(name, value, title)
+        end
+      end
+
+      content.join("\n").html_safe
+    end
+  end
+end
+
+class BootFormBuilder < SimpleForm::FormBuilder
+  def buttons(*args, &block)
+    @template.content_tag 'div', class: 'form-groups' do
+      @template.content_tag 'div', class: ['col-sm-offset-3', 'col-sm-9'] do
+        button(:submit, *args, &block)
+      end
+    end
+  end
+end

--- a/config/initializers/i18n_rails_helpers.rb
+++ b/config/initializers/i18n_rails_helpers.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-I18nRailsHelpers.setup do |config|
-  config.contextual_class = 'list-group'
-  config.contextual_link_class = 'list-group-item'
-end

--- a/config/locales/future_kids.de.yml
+++ b/config/locales/future_kids.de.yml
@@ -338,8 +338,36 @@ de:
       index:
         teacher: 'Um neue Schüler*innen für die Teilnahme anzumelden, klicken Sie links auf „Erfassen”.'
         mentor: "Schüler*innen in Ihrem Mentoring"
+  messages:
+    confirm_delete: "%{model} %{record} wirklich löschen?"
+    select_prompt:  "%{model} auswählen"
+
   crud:
+    title:
+      index:  "%{model} Liste"
+      edit:   "%{model} bearbeiten"
+      update: "%{model} bearbeiten"
+      show:   "%{model} anzeigen"
+      new:    "%{model} erfassen"
+      create: "%{model} erfassen"
+      delete: "%{model} löschen"
+      destroy: "%{model} löschen"
+    notices:
+      create: "%{model} %{record}erstellt."
+      update: "%{model} %{record}geändert."
+      destroy: "%{model} %{record}gelöscht."
     action:
+      edit: "Bearbeiten"
+      update: "Bearbeiten"
+      show: "Anzeigen"
+      new: "Erfassen"
+      create: "Erfassen"
+      delete: "Löschen"
+      destroy: "Löschen"
+      cancel: "Abbrechen"
+      back: "Zurück"
+      previous: "Zurück"
+      next: "Weiter"
       edit_schedules: Stundenplan bearbeiten
       show_kid_mentors_schedules: Mentor finden
       new_journal: Neues Lernjournal


### PR DESCRIPTION
## Summary
- Removes the `i18n_rails_helpers` gem and ports its used functionality directly into the app (`app/helpers/application_helper.rb`, `app/helpers/bootstrap_helper.rb`), since the gem's Bootstrap-flavored markup would otherwise be an extra layer to work around during the upcoming Bootstrap 5 upgrade
- Config values that were set via `config/initializers/i18n_rails_helpers.rb` are inlined; the initializer is deleted
- Adds the missing `crud.title`/`crud.notices`/`crud.action` and `messages.*` locale strings to `config/locales/future_kids.de.yml` that were previously supplied by the gem's own locale file
- Unused gem functionality (list-link helpers, enum `_t` methods on ActiveRecord models, `redirect_notice`) was intentionally not ported — zero call sites found anywhere in the app
- Bootstrap 3/4 markup inside these helpers is left as-is; updating it to Bootstrap 5 is deferred to a follow-up

## Test plan
- [x] `bundle exec rspec` — 704 examples, 0 failures
- [x] `bin/rails zeitwerk:check` — clean
- [x] Manual check of a page using the default "Aktionen" sidebar (`contextual_links`)
- [x] Manual check of flash messages, a Devise form, and a delete confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent translation support for page titles, model names, attributes, actions, and confirmation messages.
  * Added contextual CRUD links with icons and authorization-aware visibility.
  * Added Bootstrap-styled forms, page titles, labels, icons, alerts, modal headers, and navigation filters.
  * Added reusable navigation controls for links and checkboxes, including active-state styling.
  * Added improved empty-state alerts and customizable form action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->